### PR TITLE
Set up Next.js with Firebase auth and route protection

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,7 @@
+FIREBASE_PROJECT_ID=your-project-id
+FIREBASE_CLIENT_EMAIL=your-client-email
+FIREBASE_PRIVATE_KEY=your-private-key
+FIREBASE_API_KEY=your-api-key
+FIREBASE_AUTH_DOMAIN=your-auth-domain
+FIREBASE_APP_ID=your-app-id
+FIREBASE_MEASUREMENT_ID=your-measurement-id

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# aglamaz.com
+# Aglamaz App
+
+This is a minimal Next.js 14 application demonstrating Firebase Authentication with Google and Facebook providers. Authenticated routes are protected using middleware that verifies Firebase ID tokens with the Firebase Admin SDK.
+
+## Development
+
+1. Copy `.env.local.example` to `.env.local` and fill in your Firebase credentials.
+2. Install dependencies with `npm install` (requires internet access).
+3. Run the development server using `npm run dev`.
+
+## Features
+
+- App Router with server components
+- Tailwind CSS styling
+- Google and Facebook sign-in using Firebase Authentication
+- Middleware protection for routes under `/private`
+- Server-side token verification using Firebase Admin SDK

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { initAdmin, adminAuth } from './src/firebase/admin';
+
+export async function middleware(req: NextRequest) {
+  if (!req.nextUrl.pathname.startsWith('/private')) return NextResponse.next();
+  initAdmin();
+  const token = req.cookies.get('token')?.value;
+  if (!token) {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+  try {
+    await adminAuth().verifyIdToken(token);
+    return NextResponse.next();
+  } catch {
+    return NextResponse.redirect(new URL('/', req.url));
+  }
+}
+export const config = { matcher: ["/private/:path*"] };

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,18 @@
+/// <reference types="next" />
+/// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    FIREBASE_PROJECT_ID: string;
+    FIREBASE_CLIENT_EMAIL: string;
+    FIREBASE_PRIVATE_KEY: string;
+    FIREBASE_API_KEY: string;
+    FIREBASE_AUTH_DOMAIN: string;
+    FIREBASE_APP_ID: string;
+    FIREBASE_MEASUREMENT_ID?: string;
+  }
+}
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "aglamaz-app",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.1.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "firebase": "^10.8.1",
+    "firebase-admin": "^12.0.0"
+  },
+  "devDependencies": {
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0",
+    "tailwindcss": "^3.3.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const res = NextResponse.redirect(new URL('/', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));
+  res.cookies.set('token', '', { path: '/', maxAge: 0 });
+  return res;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+import './globals.css';
+import { ReactNode } from 'react';
+
+export const metadata = {
+  title: 'Aglamaz App',
+  description: 'Demo app with Firebase auth',
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { signInWithPopup, getIdToken } from 'firebase/auth';
+import { initFirebase, auth, googleProvider, facebookProvider } from '../firebase/client';
+import { useEffect } from 'react';
+
+export default function Home() {
+  const router = useRouter();
+
+  useEffect(() => {
+    initFirebase();
+  }, []);
+
+  const login = async (provider: any) => {
+    const result = await signInWithPopup(auth(), provider);
+    const token = await getIdToken(result.user);
+    document.cookie = `token=${token}; path=/`;
+    router.push('/private');
+  };
+
+  return (
+    <main className="flex flex-col items-center justify-center h-screen gap-4">
+      <button className="bg-blue-500 text-white px-4 py-2" onClick={() => login(googleProvider)}>
+        Login with Google
+      </button>
+      <button className="bg-blue-700 text-white px-4 py-2" onClick={() => login(facebookProvider)}>
+        Login with Facebook
+      </button>
+    </main>
+  );
+}

--- a/src/app/private/page.tsx
+++ b/src/app/private/page.tsx
@@ -1,0 +1,36 @@
+import { cookies } from 'next/headers';
+import { initAdmin, adminAuth } from '../../firebase/admin';
+import Link from 'next/link';
+
+export const dynamic = 'force-dynamic';
+
+export default async function PrivatePage() {
+  initAdmin();
+  const token = cookies().get('token')?.value;
+  if (!token) {
+    return (
+      <main className="flex flex-col items-center justify-center h-screen">
+        <p>No token found. Please <Link href="/">login</Link>.</p>
+      </main>
+    );
+  }
+  try {
+    const decoded = await adminAuth().verifyIdToken(token);
+    const { name, picture } = decoded;
+    return (
+      <main className="flex flex-col items-center justify-center h-screen gap-4">
+        {picture && <img src={picture} alt="avatar" className="w-24 h-24 rounded-full" />}
+        <p>Hello, {name}</p>
+        <form action="/api/logout" method="post">
+          <button className="bg-gray-800 text-white px-4 py-2" type="submit">Logout</button>
+        </form>
+      </main>
+    );
+  } catch (e) {
+    return (
+      <main className="flex flex-col items-center justify-center h-screen">
+        <p>Invalid token. Please <Link href="/">login again</Link>.</p>
+      </main>
+    );
+  }
+}

--- a/src/firebase/admin.ts
+++ b/src/firebase/admin.ts
@@ -1,0 +1,16 @@
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getAuth } from 'firebase-admin/auth';
+
+export function initAdmin() {
+  if (!getApps().length) {
+    initializeApp({
+      credential: cert({
+        projectId: process.env.FIREBASE_PROJECT_ID,
+        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+      }),
+    });
+  }
+}
+
+export const adminAuth = () => getAuth();

--- a/src/firebase/client.ts
+++ b/src/firebase/client.ts
@@ -1,0 +1,20 @@
+import { initializeApp, getApps } from 'firebase/app';
+import { getAuth, GoogleAuthProvider, FacebookAuthProvider } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
+};
+
+export function initFirebase() {
+  if (!getApps().length) {
+    initializeApp(firebaseConfig);
+  }
+}
+
+export const auth = () => getAuth();
+export const googleProvider = new GoogleAuthProvider();
+export const facebookProvider = new FacebookAuthProvider();

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- initialize a Next.js 14 app with Tailwind CSS
- add Firebase client and admin helpers
- implement login on the home page with Google and Facebook
- protect `/private` routes with middleware that verifies Firebase ID tokens
- show logged-in user data on `/private` and handle logout

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_687a3c3e4d8083228a6fa79f15f74e59