### PR TITLE
Add contact form and admin viewer

### DIFF
--- a/src/app/admin/contact-messages/page.tsx
+++ b/src/app/admin/contact-messages/page.tsx
@@ -1,0 +1,76 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { useSiteStore } from '@/store/SiteStore';
+import { MessageCircle } from 'lucide-react';
+
+interface ContactMessage {
+  id: string;
+  name: string;
+  email: string;
+  message: string;
+  createdAt: any;
+}
+
+function formatDate(ts: any) {
+  if (!ts) return '';
+  if (typeof ts === 'string') return new Date(ts).toLocaleString();
+  if (typeof ts === 'object' && ts._seconds)
+    return new Date(ts._seconds * 1000).toLocaleString();
+  return '';
+}
+
+export default function ContactMessagesPage() {
+  const site = useSiteStore(state => state.siteInfo);
+  const [messages, setMessages] = useState<ContactMessage[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const res = await fetch(`/api/admin/contact?siteId=${site?.id}`, {
+        headers: {
+          'Authorization': `Bearer ${document.cookie.match(/token=([^;]*)/)?.[1] || ''}`
+        }
+      });
+      if (res.ok) {
+        const data = await res.json();
+        setMessages(data.messages || []);
+      }
+    };
+    if (site?.id) load();
+  }, [site?.id]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50 p-4">
+      <div className="max-w-4xl mx-auto">
+        <div className="flex items-center gap-3 mb-8">
+          <MessageCircle size={32} className="text-sage-600" />
+          <h1 className="text-3xl font-bold text-sage-700">Contact Messages</h1>
+        </div>
+        {messages.length === 0 ? (
+          <Card>
+            <CardContent className="pt-6">
+              <p className="text-center text-gray-500">No messages</p>
+            </CardContent>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {messages.map(m => (
+              <Card key={m.id}>
+                <CardContent className="pt-6">
+                  <div className="flex justify-between">
+                    <div>
+                      <h3 className="font-semibold text-gray-900">{m.name}</h3>
+                      <p className="text-gray-600">{m.email}</p>
+                      <p className="text-gray-800 mt-2 whitespace-pre-line">{m.message}</p>
+                    </div>
+                    <div className="text-sm text-gray-500">{formatDate(m.createdAt)}</div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/contact/route.ts
+++ b/src/app/api/admin/contact/route.ts
@@ -1,0 +1,13 @@
+import { withAdminGuard } from '@/lib/withAdminGuard';
+import { contactRepository } from '@/repositories/ContactRepository';
+
+const handler = async (_req: Request, _ctx: any) => {
+  try {
+    const messages = await contactRepository.getAllMessages();
+    return Response.json({ messages });
+  } catch (err) {
+    return Response.json({ error: 'Failed to fetch messages' }, { status: 500 });
+  }
+};
+
+export const GET = withAdminGuard(handler);

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { contactRepository } from '@/repositories/ContactRepository';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { name, email, message } = await req.json();
+    if (!name || !email || !message) {
+      return NextResponse.json({ error: 'Missing fields' }, { status: 400 });
+    }
+    const saved = await contactRepository.addContactMessage({ name, email, message });
+    return NextResponse.json({ success: true, data: saved });
+  } catch (err) {
+    console.error('Contact form error:', err);
+    return NextResponse.json({ error: 'Failed to submit' }, { status: 500 });
+  }
+}

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+import { useState } from 'react';
+import { Loader2, CheckCircle } from 'lucide-react';
+
+export default function ContactPage() {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [message, setMessage] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !email.trim() || !message.trim()) {
+      setError('Please fill in all fields');
+      return;
+    }
+    setIsLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), email: email.trim(), message: message.trim() })
+      });
+      if (res.ok) {
+        setSuccess(true);
+        setName('');
+        setEmail('');
+        setMessage('');
+      } else {
+        const data = await res.json();
+        setError(data.error || 'Failed to submit');
+      }
+    } catch (err) {
+      setError('Failed to submit');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+        <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 text-center">
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <h3 className="text-lg font-semibold mb-2">Message sent successfully</h3>
+          <button className="mt-4 underline" onClick={() => setSuccess(false)}>Send another</button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
+      <form onSubmit={handleSubmit} className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 space-y-4">
+        <h1 className="text-2xl font-bold text-center">Contact Us</h1>
+        {error && <div className="w-full p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm">{error}</div>}
+        <div>
+          <label className="block text-gray-700 text-sm mb-1" htmlFor="name">Name</label>
+          <input id="name" type="text" value={name} onChange={e => setName(e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2" disabled={isLoading} />
+        </div>
+        <div>
+          <label className="block text-gray-700 text-sm mb-1" htmlFor="email">Email</label>
+          <input id="email" type="email" value={email} onChange={e => setEmail(e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2" disabled={isLoading} />
+        </div>
+        <div>
+          <label className="block text-gray-700 text-sm mb-1" htmlFor="message">Message</label>
+          <textarea id="message" value={message} onChange={e => setMessage(e.target.value)}
+            className="w-full border border-gray-200 rounded-lg px-3 py-2" rows={5} disabled={isLoading}></textarea>
+        </div>
+        <button type="submit" className="w-full bg-gray-900 text-white py-2 rounded-lg font-semibold hover:bg-gray-800 transition disabled:opacity-50" disabled={isLoading}>
+          {isLoading ? (<><Loader2 className="w-4 h-4 mr-2 animate-spin inline"/>Sending...</>) : 'Send'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { Menu, X, User, LogOut, Home, Users, Heart, Settings } from 'lucide-react';
+import { Menu, X, User, LogOut, Home, Users, Heart, Settings, MessageCircle } from 'lucide-react';
 import { useMemberStore } from '@/store/MemberStore';
 
 interface NavigationProps {
@@ -45,6 +45,7 @@ export default function Navigation({ user, onLogout }: NavigationProps) {
   const adminItems = [
     { name: 'Pending Members', href: '/admin/pending-members', icon: Users },
     { name: 'Site Members', href: '/admin/site-members', icon: Users },
+    { name: 'Contact Messages', href: '/admin/contact-messages', icon: MessageCircle },
   ];
 
   const handleLogout = () => {

--- a/src/entities/ContactMessage.ts
+++ b/src/entities/ContactMessage.ts
@@ -1,0 +1,7 @@
+export interface IContactMessage {
+  id: string;
+  name: string;
+  email: string;
+  message: string;
+  createdAt: any;
+}

--- a/src/repositories/ContactRepository.ts
+++ b/src/repositories/ContactRepository.ts
@@ -1,0 +1,35 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { initAdmin } from '../firebase/admin';
+
+export interface ContactMessage {
+  id: string;
+  name: string;
+  email: string;
+  message: string;
+  createdAt: Timestamp;
+}
+
+export class ContactRepository {
+  private readonly collection = 'contactMessages';
+
+  private getDb() {
+    initAdmin();
+    return getFirestore();
+  }
+
+  async addContactMessage(data: Omit<ContactMessage, 'id' | 'createdAt'>): Promise<ContactMessage> {
+    const db = this.getDb();
+    const ref = db.collection(this.collection).doc();
+    const createdAt = Timestamp.now();
+    await ref.set({ ...data, createdAt });
+    return { id: ref.id, ...data, createdAt };
+  }
+
+  async getAllMessages(): Promise<ContactMessage[]> {
+    const db = this.getDb();
+    const snap = await db.collection(this.collection).orderBy('createdAt', 'desc').get();
+    return snap.docs.map(doc => ({ id: doc.id, ...(doc.data() as Omit<ContactMessage, 'id'>) })) as ContactMessage[];
+  }
+}
+
+export const contactRepository = new ContactRepository();


### PR DESCRIPTION
## Summary
- add public contact page
- store form submissions in Firestore
- add admin page to list contact messages
- expose API routes for posting and listing messages
- show contact messages link in navigation

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688ad714a4448327ba0c039467d5a131