### PR TITLE
Hide menu for pending users

### DIFF
--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -1,44 +1,33 @@
 'use client';
 
 import React from 'react';
-import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
 import { Clock, CheckCircle, AlertCircle } from 'lucide-react';
 
 export default function PendingApprovalPage() {
   return (
-    <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-md">
-        <CardHeader className="text-center">
-          <div className="mx-auto mb-4">
-            <Clock className="w-16 h-16 text-yellow-500" />
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 text-center space-y-4">
+        <div className="mx-auto mb-4">
+          <Clock className="w-16 h-16 text-yellow-500" />
+        </div>
+        <h2 className="text-xl font-bold text-gray-900">ממתין לאישור</h2>
+        <p className="text-gray-600">בקשה שלך נשלחה בהצלחה למנהל המערכת.</p>
+        <p className="text-gray-600">תקבל הודעה כאשר הבקשה תאושר.</p>
+
+        <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+          <div className="flex items-center gap-2 text-blue-800">
+            <CheckCircle className="w-5 h-5" />
+            <span className="text-sm font-medium">בקשה נשלחה בהצלחה</span>
           </div>
-          <CardTitle className="text-xl font-bold text-gray-900">
-            ממתין לאישור
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="text-center space-y-4">
-          <p className="text-gray-600">
-            בקשה שלך נשלחה בהצלחה למנהל המערכת.
-          </p>
-          <p className="text-gray-600">
-            תקבל הודעה כאשר הבקשה תאושר.
-          </p>
-          
-          <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-            <div className="flex items-center gap-2 text-blue-800">
-              <CheckCircle className="w-5 h-5" />
-              <span className="text-sm font-medium">בקשה נשלחה בהצלחה</span>
-            </div>
+        </div>
+
+        <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+          <div className="flex items-center gap-2 text-yellow-800">
+            <AlertCircle className="w-5 h-5" />
+            <span className="text-sm font-medium">ממתין לאישור מהמנהל</span>
           </div>
-          
-          <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-            <div className="flex items-center gap-2 text-yellow-800">
-              <AlertCircle className="w-5 h-5" />
-              <span className="text-sm font-medium">ממתין לאישור מהמנהל</span>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
     </div>
   );
-} 
+}

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -4,11 +4,13 @@ import { useSiteStore } from '../store/SiteStore';
 import { useUserStore } from '../store/UserStore';
 import { useRouter } from "next/navigation";
 import Navigation from "./Navigation";
+import { useMemberStore } from '../store/MemberStore';
 
 export default function ClientLayoutShell({ children }) {
   const { user, loading, checkAuth, logout } = useUserStore();
   const setSiteInfo = useSiteStore((state) => state.setSiteInfo);
   const siteInfo = useSiteStore((state) => state.siteInfo);
+  const member = useMemberStore((state) => state.member);
   const router = useRouter();
 
   useEffect(() => {
@@ -124,8 +126,10 @@ export default function ClientLayoutShell({ children }) {
         .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
         .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
       `}</style>
-      <Navigation user={user} onLogout={handleLogout} />
+      {member && (member as any).role !== 'pending' && (
+        <Navigation user={user} onLogout={handleLogout} />
+      )}
       {children}
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- disable navigation when member role is `pending`
- restyle pending-approval page so the card is centered like the login screen

## Testing
- `npm run build` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_688b8490ce008327988508316e99dff9