### PR TITLE
Fix Google signup to create pending request

### DIFF
--- a/src/app/api/user/[id]/request-signup/route.ts
+++ b/src/app/api/user/[id]/request-signup/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { FamilyRepository } from '@/repositories/FamilyRepository';
 
 export async function POST(
   request: NextRequest,
@@ -15,21 +16,20 @@ export async function POST(
       );
     }
 
-    // Create signup request (mock implementation for now)
-    const result = {
-      success: true,
-      userId: params.id,
+    const familyRepository = new FamilyRepository();
+
+    const signupRequest = await familyRepository.createSignupRequest({
       firstName,
       email,
       siteId,
-      status: 'pending',
-      createdAt: new Date().toISOString()
-    };
+      userId: params.id,
+      status: 'pending'
+    });
 
     return NextResponse.json({
       success: true,
       message: 'Signup request submitted successfully',
-      data: result
+      data: signupRequest
     });
 
   } catch (error) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,7 +27,7 @@ export default function LoginPage() {
         const result = await signInWithPopup(auth(), googleProvider);
         const token = await getIdToken(result.user);
         document.cookie = `token=${token}; path=/`;
-        
+
         // Update user state immediately after login
         setUser({
           name: result.user.displayName,
@@ -35,7 +35,22 @@ export default function LoginPage() {
           photoURL: result.user.photoURL,
           uid: result.user.uid
         });
-        
+
+        try {
+          const firstName = result.user.displayName?.split(' ')[0] || '';
+          await fetch(`/api/user/${result.user.uid}/request-signup`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              firstName,
+              email: result.user.email,
+              siteId: siteInfo?.id
+            })
+          });
+        } catch (err) {
+          console.error('Failed to submit signup request', err);
+        }
+
         router.push("/");
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- create signup request when signing in with Google
- implement Firestore logic in request-signup API

## Testing
- `CI=true npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_688b84edbca48327a88a81c8d31dda3d