### PR TITLE
feat: display anniversaries in calendar view

### DIFF
--- a/src/app/anniversaries/page.tsx
+++ b/src/app/anniversaries/page.tsx
@@ -26,6 +26,8 @@ export default function AnniversariesPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedEvent, setSelectedEvent] = useState<AnniversaryEvent | null>(null);
   const { t } = useTranslation();
 
   const fetchEvents = async () => {
@@ -67,26 +69,64 @@ export default function AnniversariesPage() {
     }
   };
 
+  const year = selectedDate.getFullYear();
+  const month = selectedDate.getMonth();
+  const firstDay = new Date(year, month, 1).getDay();
+  const daysInMonth = new Date(year, month + 1, 0).getDate();
+  const eventsThisMonth = events.filter((ev) => ev.month === month);
+
+  const dayCells = [];
+  for (let i = 0; i < firstDay; i++) {
+    dayCells.push(<div key={`empty-${i}`} className="border p-2 h-24" />);
+  }
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dayEvents = eventsThisMonth.filter((ev) => ev.day === day);
+    dayCells.push(
+      <div key={day} className="border p-2 h-24">
+        <div className="text-xs font-bold">{day}</div>
+        {dayEvents.map((ev) => (
+          <div
+            key={ev.id}
+            onClick={() => setSelectedEvent(ev)}
+            className="text-xs cursor-pointer hover:underline"
+          >
+            {ev.name}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className="container mx-auto p-4">
       <h1 className="text-2xl font-bold mb-4">{t('anniversaries')}</h1>
+      <div className="mb-4 flex justify-center">
+        <input
+          type="month"
+          value={`${year}-${String(month + 1).padStart(2, '0')}`}
+          onChange={(e) => {
+            const [y, m] = e.target.value.split('-').map(Number);
+            setSelectedDate(new Date(y, m - 1, 1));
+          }}
+          className="border rounded px-3 py-2"
+        />
+      </div>
       {loading ? (
         <div>Loading...</div>
       ) : (
-        <ul className="mb-8 space-y-2">
-          {events.length === 0 && <li>{t('noEventsThisMonth')}</li>}
-          {events.map((ev) => (
-            <li key={ev.id} className="border p-3 rounded">
-              <div className="font-semibold">
-                {ev.name} - {ev.day}/{ev.month + 1}
+        <>
+          {eventsThisMonth.length === 0 && (
+            <div className="mb-2">{t('noEventsThisMonth')}</div>
+          )}
+          <div className="grid grid-cols-7 gap-2 mb-8 text-center">
+            {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
+              <div key={d} className="font-semibold">
+                {d}
               </div>
-              <div className="text-sm text-gray-600">
-                {ev.type}
-                {ev.description ? ` - ${ev.description}` : ''}
-              </div>
-            </li>
-          ))}
-        </ul>
+            ))}
+            {dayCells}
+          </div>
+        </>
       )}
 
       <button
@@ -156,6 +196,25 @@ export default function AnniversariesPage() {
             {saving ? t('saving') : t('addEvent')}
           </button>
         </form>
+      </Modal>
+
+      <Modal isOpen={!!selectedEvent} onClose={() => setSelectedEvent(null)}>
+        {selectedEvent && (
+          <div className="space-y-2">
+            <h2 className="text-xl font-semibold">{selectedEvent.name}</h2>
+            <div>
+              {t('date')}: {selectedEvent.day}/{selectedEvent.month + 1}
+            </div>
+            <div>
+              {t('type')}: {selectedEvent.type}
+            </div>
+            {selectedEvent.description && (
+              <div>
+                {t('description')}: {selectedEvent.description}
+              </div>
+            )}
+          </div>
+        )}
       </Modal>
     </div>
   );


### PR DESCRIPTION
## Summary
- show anniversaries in a month-based calendar
- pick different months and view events in day cells
- click events to see detailed info

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6894e61ff18c83279ad543279a1c27ce