### PR TITLE
feat: refresh firebase token

### DIFF
--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -8,6 +8,7 @@ import Header from "./Header";
 import I18nProvider from './I18nProvider';
 import i18n from '../i18n';
 import { useTranslation } from 'react-i18next';
+import { useIdTokenRefresh } from '../hooks/useIdTokenRefresh';
 
 export default function ClientLayoutShell({ children }) {
   const { user, loading, checkAuth, logout } = useUserStore();
@@ -16,6 +17,8 @@ export default function ClientLayoutShell({ children }) {
   const member = useMemberStore((state) => state.member);
   const router = useRouter();
   const { t, i18n } = useTranslation();
+
+  useIdTokenRefresh();
 
   useEffect(() => {
     checkAuth();
@@ -49,7 +52,7 @@ export default function ClientLayoutShell({ children }) {
 
 
   const handleLogout = async () => {
-    logout();
+    await logout();
     router.push('/login');
   };
 

--- a/src/hooks/useIdTokenRefresh.ts
+++ b/src/hooks/useIdTokenRefresh.ts
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { initFirebase, auth } from '../firebase/client';
+
+export function useIdTokenRefresh() {
+  const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    initFirebase();
+    const authInstance = auth();
+
+    const unsubscribe = onAuthStateChanged(authInstance, async (user) => {
+      if (user) {
+        try {
+          const token = await user.getIdToken();
+          document.cookie = `token=${token}; path=/`;
+        } catch (error) {
+          console.error('Failed to get ID token:', error);
+        }
+
+        if (refreshIntervalRef.current) {
+          clearInterval(refreshIntervalRef.current);
+        }
+
+        refreshIntervalRef.current = setInterval(async () => {
+          try {
+            const refreshedToken = await user.getIdToken(true);
+            document.cookie = `token=${refreshedToken}; path=/`;
+          } catch (error) {
+            console.error('Failed to refresh ID token:', error);
+          }
+        }, 50 * 60 * 1000); // Refresh every 50 minutes
+      } else {
+        document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+        if (refreshIntervalRef.current) {
+          clearInterval(refreshIntervalRef.current);
+          refreshIntervalRef.current = null;
+        }
+      }
+    });
+
+    return () => {
+      unsubscribe();
+      if (refreshIntervalRef.current) {
+        clearInterval(refreshIntervalRef.current);
+      }
+    };
+  }, []);
+}
+

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -2,6 +2,8 @@ import { create } from 'zustand';
 import { User } from '../entities/User';
 import { useMemberStore } from './MemberStore';
 import { useSiteStore } from './SiteStore';
+import { signOut } from 'firebase/auth';
+import { initFirebase, auth } from '../firebase/client';
 
 interface UserState {
   user: any;
@@ -9,7 +11,7 @@ interface UserState {
   setUser: (user: any) => void;
   setLoading: (loading: boolean) => void;
   checkAuth: () => Promise<void>;
-  logout: () => void;
+  logout: () => Promise<void>;
 }
 
 export const useUserStore = create<UserState>((set, get) => ({
@@ -40,10 +42,16 @@ export const useUserStore = create<UserState>((set, get) => ({
       set({ user: null, loading: false });
     }
   },
-  logout: () => {
+  logout: async () => {
+    initFirebase();
+    try {
+      await signOut(auth());
+    } catch (error) {
+      console.error('Failed to sign out:', error);
+    }
     document.cookie = 'token=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
     set({ user: null });
     const memberStore = useMemberStore.getState();
     memberStore.clearMember();
   },
-})); 
+}));


### PR DESCRIPTION
## Summary
- add `useIdTokenRefresh` hook that refreshes Firebase ID token and cookie every 50 min
- integrate token refresh hook into client layout and await logout
- sign out from Firebase on logout to clear refresh interval

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_6894f1b9b09c8327bfbcacbf5677f1e3