### PR TITLE
Use i18n strings on pending approval page

### DIFF
--- a/src/app/pending-approval/page.tsx
+++ b/src/app/pending-approval/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 
 export default function PendingApprovalPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const router = useRouter();
 
   const handleLogout = async () => {
@@ -17,7 +17,7 @@ export default function PendingApprovalPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50" dir="rtl" lang="he">
+    <div className="min-h-screen flex items-center justify-center bg-gray-50" dir={i18n.dir()} lang={i18n.language}>
       <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 text-center space-y-4">
         <div className="mx-auto mb-4">
           <Clock className="w-16 h-16 text-yellow-500" />
@@ -29,22 +29,22 @@ export default function PendingApprovalPage() {
         <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
           <div className="flex items-center gap-2 text-blue-800">
             <CheckCircle className="w-5 h-5" />
-            <span className="text-sm font-medium">בקשה נשלחה בהצלחה</span>
+            <span className="text-sm font-medium">{t('pendingApprovalRequestSent')}</span>
           </div>
         </div>
 
         <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
           <div className="flex items-center gap-2 text-yellow-800">
             <AlertCircle className="w-5 h-5" />
-            <span className="text-sm font-medium">ממתין לאישור מהמנהל</span>
+            <span className="text-sm font-medium">{t('pendingApprovalWaitingAdmin')}</span>
           </div>
         </div>
 
         <div className="flex flex-col gap-3 mt-8">
           <Link href="/contact" passHref legacyBehavior>
-            <Button className="w-full bg-black text-white rounded hover:bg-gray-800">צור קשר</Button>
+            <Button className="w-full bg-black text-white rounded hover:bg-gray-800">{t('contactUs')}</Button>
           </Link>
-          <Button className="w-full bg-gray-200 text-gray-800 rounded hover:bg-gray-300" onClick={handleLogout} type="button">התנתק</Button>
+          <Button className="w-full bg-gray-200 text-gray-800 rounded hover:bg-gray-300" onClick={handleLogout} type="button">{t('logout')}</Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace hardcoded Hebrew strings with `t()` translations
- derive language direction and code from i18n settings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_689599a10c208327b5c7aea1484acf6c