### PR TITLE
feat: crop anniversary images to 16:9

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -60,6 +60,8 @@
   "birthday": "Birthday",
   "death": "Death",
   "wedding": "Wedding",
+  "image": "Image",
+  "cropImage": "Crop Image",
   "annualEvent": "Annual event",
   "saving": "Saving...",
   "addEvent": "Add Event",

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -60,6 +60,8 @@
   "birthday": "יום הולדת",
   "death": "פטירה",
   "wedding": "חתונה",
+  "image": "תמונה",
+  "cropImage": "חתוך תמונה",
   "annualEvent": "אירוע שנתי",
   "saving": "שומר...",
   "addEvent": "הוסף אירוע",

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -60,6 +60,8 @@
   "birthday": "Doğum günü",
   "death": "Ölüm",
   "wedding": "Düğün",
+  "image": "Resim",
+  "cropImage": "Resmi Kırp",
   "annualEvent": "Yıllık etkinlik",
   "saving": "Kaydediliyor...",
   "addEvent": "Etkinlik Ekle",

--- a/src/app/api/anniversaries/route.ts
+++ b/src/app/api/anniversaries/route.ts
@@ -20,7 +20,7 @@ const getHandler = async (request: Request, context: any, user: any, member: any
 const postHandler = async (request: Request, context: any, user: any, member: any) => {
   try {
     const body = await request.json();
-    const { name, description, type, date, isAnnual } = body;
+    const { name, description, type, date, isAnnual, imageUrl } = body;
     if (!name || !date || !type) {
       return Response.json({ error: 'Missing fields' }, { status: 400 });
     }
@@ -33,6 +33,7 @@ const postHandler = async (request: Request, context: any, user: any, member: an
       date: new Date(date),
       isAnnual: Boolean(isAnnual),
       createdBy: user.uid,
+      imageUrl,
     });
     return Response.json({ event }, { status: 201 });
   } catch (error) {

--- a/src/entities/Anniversary.ts
+++ b/src/entities/Anniversary.ts
@@ -11,4 +11,5 @@ export interface AnniversaryEvent {
   isAnnual: boolean;
   createdBy: string;
   createdAt: any;
+  imageUrl?: string;
 }

--- a/src/repositories/AnniversaryRepository.ts
+++ b/src/repositories/AnniversaryRepository.ts
@@ -18,6 +18,7 @@ export class AnniversaryRepository {
     date: Date;
     isAnnual: boolean;
     createdBy: string;
+    imageUrl?: string;
   }): Promise<AnniversaryEvent> {
     const db = this.getDb();
     const now = Timestamp.now();
@@ -34,6 +35,7 @@ export class AnniversaryRepository {
       isAnnual: eventData.isAnnual,
       createdBy: eventData.createdBy,
       createdAt: now,
+      imageUrl: eventData.imageUrl || '',
     });
     const doc = await ref.get();
     return { id: doc.id, ...doc.data() } as AnniversaryEvent;


### PR DESCRIPTION
## Summary
- add image cropping UI that forces a 16:9 aspect ratio when uploading anniversary photos
- support storing optional image URLs for anniversary events
- translate new image crop labels across locales

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interrupted: prompts for configuration)*
- `npm run build` *(incomplete: build process did not finish)*

------
https://chatgpt.com/codex/tasks/task_e_68960e3de89c8327b2d0a044432fd6f5