### PR TITLE
Fix build errors by deferring Firebase initialization

### DIFF
--- a/src/app/anniversaries/page.tsx
+++ b/src/app/anniversaries/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import type { JSX } from 'react';
 import Modal from '@/components/ui/Modal';
 import { useTranslation } from 'react-i18next';
 import { Calendar as CalendarIcon } from 'lucide-react';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,13 +4,9 @@ import { ErrorBoundary } from '../components/ErrorBoundary';
 import { fetchSiteInfo } from '../firebase/admin';
 
 export default async function RootLayout({ children }) {
-  let siteInfo = null;
-  
-  try {
-    siteInfo = await fetchSiteInfo();
-  } catch (error) {
-    console.error('Failed to fetch site info:', error);
-    siteInfo = { name: 'Family' }; // fallback
+  let siteInfo: any = await fetchSiteInfo();
+  if (!siteInfo) {
+    siteInfo = { name: 'Family' };
   }
 
   return (

--- a/src/firebase/admin.ts
+++ b/src/firebase/admin.ts
@@ -2,26 +2,33 @@ import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
 
-export function initAdmin() {
-  if (!getApps().length) {
-    initializeApp({
-      credential: cert({
-        projectId: process.env.FIREBASE_PROJECT_ID,
-        clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
-        privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\n/g, '\n'),
-      }),
-    });
+export function initAdmin(): boolean {
+  if (getApps().length) {
+    return true;
   }
+  const projectId = process.env.FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const rawKey = process.env.FIREBASE_PRIVATE_KEY;
+  if (!projectId || !clientEmail || !rawKey) {
+    return false;
+  }
+  const privateKey = rawKey.replace(/\n/g, '\n');
+  initializeApp({
+    credential: cert({ projectId, clientEmail, privateKey }),
+  });
+  return true;
 }
 
 export const adminAuth = () => getAuth();
 
 export async function fetchSiteInfo() {
-  initAdmin();
-  const db = getFirestore();
-  if (!process.env.NEXT_SITE_ID) {
-    throw new Error('NEXT_SITE_ID is not set');
+  if (!initAdmin()) {
+    return null;
   }
+  if (!process.env.NEXT_SITE_ID) {
+    return null;
+  }
+  const db = getFirestore();
   const siteId = process.env.NEXT_SITE_ID;
   const doc = await db.collection('sites').doc(siteId).get();
   return doc.exists ? { id: doc.id, ...doc.data() } : null;

--- a/src/lib/withAdminGuard.ts
+++ b/src/lib/withAdminGuard.ts
@@ -3,12 +3,13 @@ import { initAdmin } from '@/firebase/admin';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
 
-initAdmin();
-const db = getFirestore();
-
 export function withAdminGuard(handler: Function) {
   return async (request: Request, context: any) => {
     try {
+      if (!initAdmin()) {
+        return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+      }
+      const db = getFirestore();
       // Extract token from Authorization header or cookies
       const authHeader = request.headers.get('authorization');
       let token = authHeader?.replace('Bearer ', '');

--- a/src/lib/withMemberGuard.ts
+++ b/src/lib/withMemberGuard.ts
@@ -3,12 +3,13 @@ import { initAdmin } from '@/firebase/admin';
 import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
 
-initAdmin();
-const db = getFirestore();
-
 export function withMemberGuard(handler: Function) {
   return async (request: Request, context: any) => {
     try {
+      if (!initAdmin()) {
+        return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
+      }
+      const db = getFirestore();
       const authHeader = request.headers.get('authorization');
       let token = authHeader?.replace('Bearer ', '');
       if (!token && 'cookies' in request) {


### PR DESCRIPTION
## Summary
- import React JSX types to resolve missing `JSX` namespace error
- lazily initialize Firebase admin and add guards for missing credentials
- initialize Firestore in auth guards only during requests and provide fallback site info

## Testing
- `npm run build`
- `npm run lint` *(fails: requires interactive config)*

------
https://chatgpt.com/codex/tasks/task_e_689717ea00148327b14292f5cd2c08fa