### PR TITLE
feat: template-based admin notification emails

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-dom": "18.2.0",
     "react-i18next": "^15.6.1",
     "react-icons": "^5.5.0",
-    "zustand": "^5.0.6"
+    "zustand": "^5.0.6",
+    "pug": "^3.0.2"
   },
   "devDependencies": {
     "@types/react": "19.1.8",

--- a/src/templates/admin-notifications/contact_form.pug
+++ b/src/templates/admin-notifications/contact_form.pug
@@ -1,0 +1,4 @@
+h2 New Contact Form Submission
+p You received a new message from #{name} (#{email}):
+p #{message}
+

--- a/src/templates/admin-notifications/pending_member.pug
+++ b/src/templates/admin-notifications/pending_member.pug
@@ -1,0 +1,7 @@
+h2 New Pending Member
+p The following user is pending approval:
+ul
+  li strong Name: #{firstName}
+  li strong Email: #{email}
+  li strong Status: #{status}
+


### PR DESCRIPTION
## Summary
- add pug dependency and email templates for admin notifications
- render event-specific HTML emails with templates, filtering out IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(aborted: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6898f2c9b63c83279b235c5590f32873