### PR TITLE
Implement OAuth PKCE flow with token rotation

### DIFF
--- a/src/app/api/auth/callback/route.ts
+++ b/src/app/api/auth/callback/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { signAccessToken, signRefreshToken, setAuthCookies } from '@/lib/auth';
+
+export async function GET(req: NextRequest) {
+  try {
+    const url = new URL(req.url);
+    const code = url.searchParams.get('code');
+    const state = url.searchParams.get('state');
+    const storedState = req.cookies.get('oauth_state')?.value;
+    const codeVerifier = req.cookies.get('pkce_verifier')?.value;
+
+    if (!code || !state || state !== storedState || !codeVerifier) {
+      console.error('OAuth callback state mismatch');
+      return NextResponse.redirect(new URL('/login', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));
+    }
+
+    const tokenRes = await fetch(process.env.OAUTH_TOKEN_URL || '', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        client_id: process.env.OAUTH_CLIENT_ID || '',
+        redirect_uri: `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/callback`,
+        code_verifier: codeVerifier,
+      }).toString(),
+    });
+
+    if (!tokenRes.ok) {
+      console.error('Token exchange failed');
+      return NextResponse.redirect(new URL('/login', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));
+    }
+
+    const tokenJson = await tokenRes.json();
+    const userId = tokenJson.user_id || tokenJson.sub || 'user';
+
+    const access = signAccessToken({ sub: userId });
+    const refresh = signRefreshToken({ sub: userId });
+
+    const res = NextResponse.redirect(new URL('/', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));
+    setAuthCookies(res, access, refresh);
+    res.cookies.set('oauth_state', '', { path: '/', maxAge: 0 });
+    res.cookies.set('pkce_verifier', '', { path: '/', maxAge: 0 });
+    return res;
+  } catch (err) {
+    console.error('OAuth callback error', err);
+    return NextResponse.redirect(new URL('/login', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));
+  }
+}

--- a/src/app/api/auth/logout/route.ts
+++ b/src/app/api/auth/logout/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyRefreshToken, revokeRefreshToken, clearAuthCookies } from '@/lib/auth';
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get('refresh_token')?.value;
+  if (token) {
+    const payload = verifyRefreshToken(token);
+    if (payload) {
+      revokeRefreshToken(payload.sub);
+    }
+  }
+  const res = NextResponse.redirect(new URL('/login', process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000'));
+  clearAuthCookies(res);
+  return res;
+}

--- a/src/app/api/auth/refresh/route.ts
+++ b/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyRefreshToken, signAccessToken, rotateRefreshToken, setAuthCookies, refreshRateLimit } from '@/lib/auth';
+
+export async function POST(req: NextRequest) {
+  const token = req.cookies.get('refresh_token')?.value;
+  if (!token) {
+    console.error('Missing refresh token');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const payload = verifyRefreshToken(token);
+  if (!payload) {
+    console.error('Refresh token invalid or reuse detected');
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const now = Date.now();
+  const last = refreshRateLimit.get(payload.sub) || 0;
+  if (now - last < 5000) {
+    return NextResponse.json({ error: 'Too Many Requests' }, { status: 429 });
+  }
+  refreshRateLimit.set(payload.sub, now);
+
+  const access = signAccessToken({ sub: payload.sub });
+  const newRefresh = rotateRefreshToken(payload.sub);
+
+  const res = NextResponse.json({ ok: true });
+  setAuthCookies(res, access, newRefresh);
+  return res;
+}

--- a/src/app/api/auth/start/route.ts
+++ b/src/app/api/auth/start/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { randomBytes, createHash } from 'crypto';
+
+export async function GET(req: NextRequest) {
+  const state = randomBytes(16).toString('hex');
+  const codeVerifier = randomBytes(32).toString('base64url');
+  const codeChallenge = createHash('sha256').update(codeVerifier).digest('base64url');
+
+  const authUrl = new URL(process.env.OAUTH_AUTHORIZE_URL || '');
+  authUrl.searchParams.set('client_id', process.env.OAUTH_CLIENT_ID || '');
+  authUrl.searchParams.set('response_type', 'code');
+  authUrl.searchParams.set('redirect_uri', `${process.env.NEXT_PUBLIC_BASE_URL}/api/auth/callback`);
+  authUrl.searchParams.set('scope', process.env.OAUTH_SCOPE || '');
+  authUrl.searchParams.set('state', state);
+  authUrl.searchParams.set('code_challenge', codeChallenge);
+  authUrl.searchParams.set('code_challenge_method', 'S256');
+
+  const res = NextResponse.redirect(authUrl.toString());
+  res.cookies.set('oauth_state', state, { httpOnly: true, secure: true, path: '/', maxAge: 300 });
+  res.cookies.set('pkce_verifier', codeVerifier, { httpOnly: true, secure: true, path: '/', maxAge: 300 });
+  return res;
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,138 @@
+import { createHash, randomBytes, createSign, createVerify } from 'crypto';
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+
+export type JwtPayload = { sub: string; roles?: string[]; siteId?: string; exp: number; jti?: string };
+
+// In-memory store for hashed refresh tokens and last refresh timestamps
+const refreshStore = new Map<string, string>();
+const refreshRateLimit = new Map<string, number>();
+
+function base64url(input: Buffer | string) {
+  return Buffer.from(input).toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
+}
+
+function signJwt(payload: object, expiresInSec: number): string {
+  const privateKey = process.env.JWT_PRIVATE_KEY;
+  if (!privateKey) throw new Error('JWT_PRIVATE_KEY not set');
+  const header = { alg: 'RS256', typ: 'JWT' };
+  const exp = Math.floor(Date.now() / 1000) + expiresInSec;
+  const body = { ...payload, exp };
+  const headerEncoded = base64url(JSON.stringify(header));
+  const payloadEncoded = base64url(JSON.stringify(body));
+  const unsigned = `${headerEncoded}.${payloadEncoded}`;
+  const sign = createSign('RSA-SHA256');
+  sign.update(unsigned);
+  const signature = sign.sign(privateKey);
+  const signatureEncoded = base64url(signature);
+  return `${unsigned}.${signatureEncoded}`;
+}
+
+function verifyJwt(token: string): JwtPayload | null {
+  try {
+    const publicKey = process.env.JWT_PUBLIC_KEY;
+    if (!publicKey) throw new Error('JWT_PUBLIC_KEY not set');
+    const [h, p, s] = token.split('.');
+    const verify = createVerify('RSA-SHA256');
+    verify.update(`${h}.${p}`);
+    const signature = Buffer.from(s, 'base64');
+    if (!verify.verify(publicKey, signature)) return null;
+    const payload: JwtPayload = JSON.parse(Buffer.from(p, 'base64').toString());
+    const skew = 5; // seconds of allowed clock skew
+    if (payload.exp < Math.floor(Date.now() / 1000) - skew) return null;
+    return payload;
+  } catch (err) {
+    console.error('JWT verification failed', err);
+    return null;
+  }
+}
+
+export function signAccessToken(user: { sub: string; roles?: string[]; siteId?: string }) {
+  return signJwt(user, 60 * 5); // 5 minutes
+}
+
+export function signRefreshToken(user: { sub: string }) {
+  const jti = randomBytes(16).toString('hex');
+  const token = signJwt({ sub: user.sub, jti }, 60 * 60 * 24 * 7); // 7 days
+  refreshStore.set(user.sub, hashToken(token));
+  return token;
+}
+
+export function verifyAccessToken(token: string) {
+  return verifyJwt(token);
+}
+
+export function verifyRefreshToken(token: string) {
+  const payload = verifyJwt(token);
+  if (!payload?.sub) return null;
+  const hashed = hashToken(token);
+  const stored = refreshStore.get(payload.sub);
+  if (stored !== hashed) {
+    // Reuse detection
+    refreshStore.delete(payload.sub);
+    return null;
+  }
+  return payload;
+}
+
+export function rotateRefreshToken(userId: string) {
+  return signRefreshToken({ sub: userId });
+}
+
+export function revokeRefreshToken(userId: string) {
+  refreshStore.delete(userId);
+}
+
+export function hashToken(token: string) {
+  return createHash('sha256').update(token).digest('hex');
+}
+
+export function setAuthCookies(res: NextResponse, access: string, refresh?: string) {
+  res.cookies.set('access_token', access, {
+    httpOnly: true,
+    secure: true,
+    path: '/',
+    sameSite: 'lax',
+  });
+  if (refresh) {
+    res.cookies.set('refresh_token', refresh, {
+      httpOnly: true,
+      secure: true,
+      path: '/',
+      sameSite: 'lax',
+    });
+  }
+}
+
+export function clearAuthCookies(res: NextResponse) {
+  res.cookies.set('access_token', '', { path: '/', maxAge: 0 });
+  res.cookies.set('refresh_token', '', { path: '/', maxAge: 0 });
+}
+
+export async function getServerAuth() {
+  const cookieStore = cookies();
+  const token = cookieStore.get('access_token')?.value;
+  if (!token) return null;
+  return verifyAccessToken(token);
+}
+
+export function withAuth(
+  handler: (req: NextRequest, auth: JwtPayload) => Promise<NextResponse> | NextResponse,
+  options?: { role?: string; siteId?: string }
+) {
+  return async (req: NextRequest) => {
+    const token = req.cookies.get('access_token')?.value;
+    if (!token) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    const payload = verifyAccessToken(token);
+    if (!payload) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    if (options?.role && !payload.roles?.includes(options.role)) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    if (options?.siteId && payload.siteId !== options.siteId) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+    }
+    return handler(req, payload);
+  };
+}
+
+export { refreshRateLimit };

--- a/src/utils/apiFetch.ts
+++ b/src/utils/apiFetch.ts
@@ -1,0 +1,13 @@
+export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {}) {
+  const res = await fetch(input, { ...init, credentials: 'include' });
+  if (res.status === 401) {
+    const refresh = await fetch('/api/auth/refresh', { method: 'POST', credentials: 'include' });
+    if (refresh.ok) {
+      return fetch(input, { ...init, credentials: 'include' });
+    } else {
+      window.location.href = '/login';
+      throw new Error('Unauthorized');
+    }
+  }
+  return res;
+}


### PR DESCRIPTION
## Summary
- add OAuth start endpoint generating state and PKCE verifier
- handle callback to validate state, exchange code, and issue JWT cookies
- support refresh token rotation, logout, and middleware validation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_689d58aba1bc8327b23734bd02ac9557