### PR TITLE
Create backend session for Google login

### DIFF
--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { initAdmin, adminAuth } from '@/firebase/admin';
+import { signAccessToken, signRefreshToken } from '@/lib/auth';
+
+export async function POST(req: NextRequest) {
+  try {
+    const { idToken } = await req.json();
+    if (!idToken) {
+      return NextResponse.json({ error: 'Missing idToken' }, { status: 400 });
+    }
+
+    initAdmin();
+    const decoded = await adminAuth().verifyIdToken(idToken);
+    const access = signAccessToken({ sub: decoded.uid });
+    const refresh = signRefreshToken({ sub: decoded.uid });
+
+    const secure = process.env.NODE_ENV === 'production';
+    const res = NextResponse.json({ token: access });
+    res.cookies.set('refresh_token', refresh, {
+      httpOnly: true,
+      secure,
+      path: '/api/auth/refresh',
+      sameSite: 'lax',
+    });
+    return res;
+  } catch (error) {
+    console.error('Session creation failed', error);
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -30,8 +30,17 @@ export default function LoginPage() {
       initFirebase();
       if (auth && googleProvider) {
         const result = await signInWithPopup(auth(), googleProvider);
-        const token = await getIdToken(result.user);
-        document.cookie = `token=${token}; path=/`;
+        const idToken = await getIdToken(result.user);
+        const sessionRes = await fetch('/api/auth/login', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ idToken }),
+          credentials: 'include',
+        });
+        if (!sessionRes.ok) throw new Error('Session creation failed');
+        const { token } = await sessionRes.json();
+        const secureFlag = process.env.NODE_ENV === 'production' ? '; Secure' : '';
+        document.cookie = `token=${token}; path=/` + secureFlag;
 
         // Update user state immediately after login
         setUser({


### PR DESCRIPTION
## Summary
- Create `/api/auth/login` endpoint that exchanges a Google ID token for JWT and refresh tokens
- Update Google login flow to call the new backend session endpoint and store returned JWT

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_689ebcb35a108327a546dfb86779c9ca