### PR TITLE
Refactor auth to middleware and backend

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,13 +37,11 @@ export default function LoginPage() {
         if (!sessionRes.ok) throw new Error('Session creation failed');
 
         // Update user state immediately after login
-        console.log("login: setting user")
         setUser({
           name: result.user.displayName,
           email: result.user.email,
           user_id: result.user.uid
         });
-        console.log("login: after setting user")
       }
     } catch (error) {
       setError(t('googleLoginFailed'));
@@ -113,11 +111,10 @@ export default function LoginPage() {
   };
 
   if (showSignup) {
-    console.log("signup -> pending-approval")
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
         <SignupForm
-          onSuccess={() => router.push('/pending-approval')}
+          onSuccess={() => router.push('/pending-member')}
           onCancel={() => setShowSignup(false)}
         />
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,14 @@
 'use client';
 
-import React, {useState, useEffect, useRef} from "react";
+import React from "react";
 import WelcomeHero from "../components/home/WelcomeHero";
 import FamilyOverview from "../components/FamilyOverview";
-import {useSiteStore} from "../store/SiteStore";
 import {useUserStore} from "../store/UserStore";
-import {useRouter} from "next/navigation";
 import {useTranslation} from 'react-i18next';
-import { apiFetch } from '../utils/apiFetch';
 
 export default function Home() {
     const {t} = useTranslation();
-    const {user, loading,setUser} = useUserStore();
-    const siteInfo = useSiteStore((state) => state.siteInfo);
-    const router = useRouter();
+    const {user, loading} = useUserStore();
 
     if (loading) {
         return (
@@ -21,11 +16,6 @@ export default function Home() {
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sage-600"></div>
             </div>
         );
-    }
-
-    if (!user) {
-        router.push('/login');
-        return null;
     }
 
     return (

--- a/src/app/pending-member/page.tsx
+++ b/src/app/pending-member/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { apiFetch } from '@/utils/apiFetch';
 
-export default function PendingApprovalPage() {
+export default function PendingMemberPage() {
   const { t, i18n } = useTranslation();
   const router = useRouter();
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -8,7 +8,7 @@ export default function SignupPage() {
   const router = useRouter();
 
   const handleSuccess = () => {
-    router.push('/pending-approval');
+    router.push('/pending-member');
   };
 
   const handleCancel = () => {

--- a/src/app/signup/verify/page.tsx
+++ b/src/app/signup/verify/page.tsx
@@ -78,9 +78,9 @@ export default function VerifySignupPage() {
         setStatus('success');
         setMessage('Email verified successfully! Your request is now pending admin approval.');
 
-        // Redirect to pending approval page after 3 seconds
+        // Redirect to pending member page after 3 seconds
         setTimeout(() => {
-          router.push('/pending-approval');
+          router.push('/pending-member');
         }, 3000);
 
       } catch (error) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,3 @@
-import { apiFetch } from "@/utils/apiFetch";
 import { ACCESS_TOKEN } from "@/constants";
 import { apiFetchFromMiddleware, verifyAccessToken } from 'src/lib/edgeAuth'
 import { NextRequest, NextResponse } from 'next/server';
@@ -8,7 +7,7 @@ const PUBLIC_PATHS = [
   '/contact',
   '/favicon.ico',
   '/_next',
-  '/pending-approval',
+  '/pending-member',
   '/locales'
 ];
 
@@ -29,18 +28,16 @@ export async function middleware(request: NextRequest) {
       return NextResponse.next();
     }
 
-    if (path !== '/pending-approval') {
-      console.log("check membership")
+    if (path !== '/pending-member') {
       const siteId = process.env.NEXT_SITE_ID;
       const memberRes = await apiFetchFromMiddleware(request, `/api/user/member-info?siteId=${siteId}`);
-      console.log(memberRes);
       if (!memberRes.ok) {
-        return NextResponse.redirect(new URL('/pending-approval', request.url));
+        return NextResponse.redirect(new URL('/pending-member', request.url));
       }
     }
   } catch (error) {
     console.error(`middleware error, accessing ${path}`, error);
-    NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.redirect(new URL('/login', request.url));
   }
 
   return NextResponse.next();


### PR DESCRIPTION
## Summary
- move pending approval flow to `/pending-member`
- drop client-side auth check on home page
- guard APIs with redirect-based member check

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `CI=1 npm run build` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0cea2c88327ae104dd4d12216ef