### PR TITLE
Refactor auth flow and pending member redirect

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -37,13 +37,11 @@ export default function LoginPage() {
         if (!sessionRes.ok) throw new Error('Session creation failed');
 
         // Update user state immediately after login
-        console.log("login: setting user")
         setUser({
           name: result.user.displayName,
           email: result.user.email,
           user_id: result.user.uid
         });
-        console.log("login: after setting user")
       }
     } catch (error) {
       setError(t('googleLoginFailed'));
@@ -113,11 +111,10 @@ export default function LoginPage() {
   };
 
   if (showSignup) {
-    console.log("signup -> pending-approval")
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 p-4">
         <SignupForm
-          onSuccess={() => router.push('/pending-approval')}
+          onSuccess={() => router.push('/pending-member')}
           onCancel={() => setShowSignup(false)}
         />
       </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,14 @@
 'use client';
 
-import React, {useState, useEffect, useRef} from "react";
+import React from "react";
 import WelcomeHero from "../components/home/WelcomeHero";
 import FamilyOverview from "../components/FamilyOverview";
-import {useSiteStore} from "../store/SiteStore";
 import {useUserStore} from "../store/UserStore";
-import {useRouter} from "next/navigation";
 import {useTranslation} from 'react-i18next';
-import { apiFetch } from '../utils/apiFetch';
 
 export default function Home() {
     const {t} = useTranslation();
-    const {user, loading,setUser} = useUserStore();
-    const siteInfo = useSiteStore((state) => state.siteInfo);
-    const router = useRouter();
+    const {user, loading} = useUserStore();
 
     if (loading) {
         return (
@@ -21,11 +16,6 @@ export default function Home() {
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sage-600"></div>
             </div>
         );
-    }
-
-    if (!user) {
-        router.push('/login');
-        return null;
     }
 
     return (

--- a/src/app/pending-member/page.tsx
+++ b/src/app/pending-member/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useTranslation } from 'react-i18next';
 import { apiFetch } from '@/utils/apiFetch';
 
-export default function PendingApprovalPage() {
+export default function PendingMemberPage() {
   const { t, i18n } = useTranslation();
   const router = useRouter();
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -8,7 +8,7 @@ export default function SignupPage() {
   const router = useRouter();
 
   const handleSuccess = () => {
-    router.push('/pending-approval');
+    router.push('/pending-member');
   };
 
   const handleCancel = () => {

--- a/src/app/signup/verify/page.tsx
+++ b/src/app/signup/verify/page.tsx
@@ -80,7 +80,7 @@ export default function VerifySignupPage() {
 
         // Redirect to pending approval page after 3 seconds
         setTimeout(() => {
-          router.push('/pending-approval');
+          router.push('/pending-member');
         }, 3000);
 
       } catch (error) {

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -1,14 +1,13 @@
 'use client';
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useSiteStore } from '../store/SiteStore';
 import { useUserStore } from '../store/UserStore';
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import { useMemberStore } from '../store/MemberStore';
 import Header from "./Header";
 import I18nProvider from './I18nProvider';
 import { useTranslation } from 'react-i18next';
 import { Loader } from "../components/ui/Loader";
-import { useSearchParams } from "next/navigation";
 
 export default function ClientLayoutShell({ children }) {
   const { user, loading, logout } = useUserStore();
@@ -16,30 +15,7 @@ export default function ClientLayoutShell({ children }) {
   const siteInfo = useSiteStore((state) => state.siteInfo);
   const member = useMemberStore((state) => state.member);
   const router = useRouter();
-  const { t, i18n } = useTranslation();
-  const pathname = usePathname();
-  const publicRoutes = ['/login'];
-  const isPublic = publicRoutes.includes(pathname);
-  const isAuthRoute = pathname === "/login" || pathname.startsWith("/auth");
-  const searchParams = useSearchParams();
-
-  // // 1) Redirect unauthenticated ONLY from protected routes
-  // useEffect(() => {
-  //   if (loading) return;
-  //   if (!user && !isAuthRoute) {
-  //     router.replace(`/login?next=${encodeURIComponent(pathname)}`);
-  //   }
-  // }, [loading, user, isAuthRoute, pathname, router]);
-  //
-  // // 2) After login, leave /login (or /auth/*) to the intended page
-  // useEffect(() => {
-  //   if (loading) return;
-  //   if (user && isAuthRoute) {
-  //     const next = searchParams.get("next") || "/";
-  //     const target = next === "/login" || next.startsWith("/auth") ? "/" : next;
-  //     router.replace(target);
-  //   }
-  // }, [loading, user, isAuthRoute, searchParams, router]);
+  const { i18n } = useTranslation();
 
   useEffect(() => {
     // Hydrate Zustand store with site info from server
@@ -87,8 +63,6 @@ export default function ClientLayoutShell({ children }) {
       </div>
     );
   }
-  if (!isPublic && !user) return null;
-
   return (
     <I18nProvider>
       <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50">

--- a/src/lib/edgeAuth.ts
+++ b/src/lib/edgeAuth.ts
@@ -53,7 +53,6 @@ export async function apiFetchFromMiddleware(
     },
   };
 
-  console.log(`target: ${targetUrl}`)
   const res = await fetch(targetUrl, withCookies);
   if (res.status !== 401) return res;
 

--- a/src/lib/withMemberGuard.ts
+++ b/src/lib/withMemberGuard.ts
@@ -40,7 +40,7 @@ export function withMemberGuard(handler: Function) {
         .limit(1)
         .get();
       if (memberSnap.empty) {
-        return NextResponse.json({ error: 'Member not found' }, { status: 404 });
+        return NextResponse.json({ error: 'Member not found' }, { status: 403 });
       }
       const doc = memberSnap.docs[0];
       context.member = doc.data();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,4 +1,3 @@
-import { apiFetch } from "@/utils/apiFetch";
 import { ACCESS_TOKEN } from "@/constants";
 import { apiFetchFromMiddleware, verifyAccessToken } from 'src/lib/edgeAuth'
 import { NextRequest, NextResponse } from 'next/server';
@@ -8,7 +7,7 @@ const PUBLIC_PATHS = [
   '/contact',
   '/favicon.ico',
   '/_next',
-  '/pending-approval',
+  '/pending-member',
   '/locales'
 ];
 
@@ -29,18 +28,16 @@ export async function middleware(request: NextRequest) {
       return NextResponse.next();
     }
 
-    if (path !== '/pending-approval') {
-      console.log("check membership")
+    if (path !== '/pending-member') {
       const siteId = process.env.NEXT_SITE_ID;
       const memberRes = await apiFetchFromMiddleware(request, `/api/user/member-info?siteId=${siteId}`);
-      console.log(memberRes);
       if (!memberRes.ok) {
-        return NextResponse.redirect(new URL('/pending-approval', request.url));
+        return NextResponse.redirect(new URL('/pending-member', request.url));
       }
     }
   } catch (error) {
     console.error(`middleware error, accessing ${path}`, error);
-    NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.redirect(new URL('/login', request.url));
   }
 
   return NextResponse.next();

--- a/src/services/GmailService.ts
+++ b/src/services/GmailService.ts
@@ -64,7 +64,6 @@ export class GmailService {
         },
       });
 
-      console.log(`Email sent successfully to ${to}`);
     } catch (error) {
       console.error('Error sending email:', error);
       throw new Error('Failed to send email');

--- a/src/store/MemberStore.ts
+++ b/src/store/MemberStore.ts
@@ -27,7 +27,6 @@ export const useMemberStore = create<MemberState>((set, get) => ({
       }
 
       const data = await response.json();
-      console.log("fetchMember", data);
       set({ member: data.member, loading: false });
     } catch (error) {
       set({ 

--- a/src/utils/apiFetch.ts
+++ b/src/utils/apiFetch.ts
@@ -9,5 +9,9 @@ export async function apiFetch(input: RequestInfo | URL, init: RequestInit = {})
       throw new Error('Unauthorized');
     }
   }
+  if (res.status === 403) {
+    window.location.href = '/pending-member';
+    throw new Error('Pending member');
+  }
   return res;
 }


### PR DESCRIPTION
## Summary
- Move auth checks to middleware and server utilities while dropping client-side enforcement
- Redirect unauthenticated or pending users to `/login` or new `/pending-member` page
- Clean up leftover debug code and rename pending approval route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run build` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68a2c0cea2c88327ae104dd4d12216ef