### PR TITLE
refactor: use apiFetch for member lookup

### DIFF
--- a/src/store/MemberStore.ts
+++ b/src/store/MemberStore.ts
@@ -20,14 +20,7 @@ export const useMemberStore = create<MemberState>((set, get) => ({
     try {
       set({ loading: true, error: null });
       
-      const response = await apiFetch(`/api/user/${userId}/member-info?siteId=${encodeURIComponent(siteId)}`);
-
-      if (!response.ok) {
-        throw new Error('Failed to fetch member info');
-      }
-
-      const data = await response.json();
-      console.log("fetchMember", data);
+      const data = await apiFetch<{ member: IMember }>(`/api/user/${userId}/member-info?siteId=${siteId}`);
       set({ member: data.member, loading: false });
     } catch (error) {
       set({ 


### PR DESCRIPTION
## Summary
- refactor member store fetchMember to use typed `apiFetch`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: requires interactive ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68a37dc4035c8327ab480b47f58c12dc