### PR TITLE
Use typed apiFetch responses throughout app

### DIFF
--- a/src/app/admin/pending-members/page.tsx
+++ b/src/app/admin/pending-members/page.tsx
@@ -42,8 +42,9 @@ export default function PendingMembersPage() {
   const fetchPendingMembers = async () => {
     try {
       setLoading(true);
-      const data = await apiFetch(`/api/user/${user?.user_id}/pending-members/${site?.id}`);
-
+      const data = await apiFetch<PendingMember[]>(
+        `/api/user/${user?.user_id}/pending-members/${site?.id}`,
+      );
       setPendingMembers(data || []);
     } catch (error) {
       setError(t('failedToLoadPendingMembers'));
@@ -64,33 +65,24 @@ export default function PendingMembersPage() {
     try {
       setActionLoading(memberId);
       setMessage(null);
-      const response = await apiFetch(`/api/user/${user?.user_id}/${action}-member?siteId=${site?.id}`, {
+      await apiFetch<void>(`/api/user/${user?.user_id}/${action}-member?siteId=${site?.id}`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ signupRequestId: memberId })
+        body: JSON.stringify({ signupRequestId: memberId }),
       });
 
-      const data = await response.json();
-
-      if (response.ok) {
-        setMessage({
-          type: 'success',
-          text: action === 'approve' ? t('memberApproved') : t('memberRejected')
-        });
-        // Remove the member from the list
-        setPendingMembers(prev => prev.filter(member => member.id !== memberId));
-      } else {
-        setMessage({
-          type: 'error',
-          text: data.error || t(action === 'approve' ? 'failedToApproveMember' : 'failedToRejectMember')
-        });
-      }
+      setMessage({
+        type: 'success',
+        text: action === 'approve' ? t('memberApproved') : t('memberRejected'),
+      });
+      // Remove the member from the list
+      setPendingMembers(prev => prev.filter(member => member.id !== memberId));
     } catch (error) {
       setMessage({
         type: 'error',
-        text: t(action === 'approve' ? 'failedToApproveMember' : 'failedToRejectMember')
+        text: t(action === 'approve' ? 'failedToApproveMember' : 'failedToRejectMember'),
       });
     } finally {
       setActionLoading(null);

--- a/src/app/admin/site-members/page.tsx
+++ b/src/app/admin/site-members/page.tsx
@@ -26,8 +26,7 @@ export default function SiteMembersPage() {
 
   useEffect(() => {
     if (!site?.id) return;
-    apiFetch(`/api/site/${site.id}/members`)
-      .then(res => res.json())
+    apiFetch<{ members: IMember[] }>(`/api/site/${site.id}/members`)
       .then(data => setMembers(data.members || []));
   }, [site?.id]);
 

--- a/src/app/anniversaries/page.tsx
+++ b/src/app/anniversaries/page.tsx
@@ -54,11 +54,8 @@ export default function AnniversariesPage() {
   const fetchEvents = async () => {
     setLoading(true);
     try {
-      const res = await apiFetch('/api/anniversaries');
-      if (res.ok) {
-        const data = await res.json();
-        setEvents(data.events || []);
-      }
+      const data = await apiFetch<{ events: AnniversaryEvent[] }>('/api/anniversaries');
+      setEvents(data.events || []);
     } finally {
       setLoading(false);
     }
@@ -137,31 +134,27 @@ export default function AnniversariesPage() {
       }
 
       const payload = { ...form, imageUrl };
-      let res: Response;
       if (editEvent) {
-        res = await apiFetch(`/api/anniversaries/${editEvent.id}`, {
+        await apiFetch<void>(`/api/anniversaries/${editEvent.id}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         });
       } else {
-        res = await apiFetch('/api/anniversaries', {
+        await apiFetch<void>('/api/anniversaries', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         });
       }
-      if (res.ok) {
-        setForm({ name: '', description: '', date: '', type: 'birthday', isAnnual: true, imageUrl: '' });
-        setImageFile(null);
-        setEditEvent(null);
-        setIsModalOpen(false);
-        setImageSrc('');
-        fetchEvents();
-      } else {
-        const data = await res.json();
-        setError(data.error || 'Failed to save');
-      }
+      setForm({ name: '', description: '', date: '', type: 'birthday', isAnnual: true, imageUrl: '' });
+      setImageFile(null);
+      setEditEvent(null);
+      setIsModalOpen(false);
+      setImageSrc('');
+      fetchEvents();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save');
     } finally {
       setSaving(false);
     }
@@ -170,7 +163,7 @@ export default function AnniversariesPage() {
   const handleDelete = async (id: string) => {
     try {
       if (!confirm('Are you sure?')) return;
-      await apiFetch(`/api/anniversaries/${id}`, { method: 'DELETE' });
+      await apiFetch<void>(`/api/anniversaries/${id}`, { method: 'DELETE' });
       setSelectedEvent(null);
       fetchEvents();
     } catch (err) {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -23,22 +23,17 @@ export default function ContactPage() {
     setIsLoading(true);
     setError('');
     try {
-      const res = await apiFetch('/api/contact', {
+      await apiFetch<void>('/api/contact', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: name.trim(), email: email.trim(), message: message.trim() })
       });
-      if (res.ok) {
-        setSuccess(true);
-        setName('');
-        setEmail('');
-        setMessage('');
-      } else {
-        const data = await res.json();
-        setError(data.error || 'Failed to submit');
-      }
+      setSuccess(true);
+      setName('');
+      setEmail('');
+      setMessage('');
     } catch (err) {
-      setError('Failed to submit');
+      setError(err instanceof Error ? err.message : 'Failed to submit');
     } finally {
       setIsLoading(false);
     }

--- a/src/app/pending-member/page.tsx
+++ b/src/app/pending-member/page.tsx
@@ -13,7 +13,7 @@ export default function PendingMemberPage() {
   const router = useRouter();
 
   const handleLogout = async () => {
-    await apiFetch('/api/logout', { method: 'POST' });
+    await apiFetch<void>('/api/logout', { method: 'POST' });
     router.push('/login');
   };
 

--- a/src/app/signup/verify/page.tsx
+++ b/src/app/signup/verify/page.tsx
@@ -27,18 +27,13 @@ export default function VerifySignupPage() {
 
       try {
         // Step 1: Verify the token with the server
-        const verifyResponse = await apiFetch('/api/signup/verify', {
+        await apiFetch<void>('/api/signup/verify', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({ token })
         });
-
-        if (!verifyResponse.ok) {
-          const errorData = await verifyResponse.json();
-          throw new Error(errorData.error || 'Verification failed');
-        }
 
         // Step 2: Authenticate with Firebase
         initFirebase();
@@ -59,21 +54,17 @@ export default function VerifySignupPage() {
         setUser(userData);
 
         // Step 3: Complete the verification with user ID
-        const completeResponse = await apiFetch('/api/signup/complete-verification', {
+        await apiFetch<void>('/api/signup/complete-verification', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
             'Authorization': `Bearer ${firebaseToken}`
           },
-          body: JSON.stringify({ 
+          body: JSON.stringify({
             token,
-            userId: result.user.uid 
+            userId: result.user.uid
           })
         });
-
-        if (!completeResponse.ok) {
-          throw new Error('Failed to complete verification');
-        }
 
         setStatus('success');
         setMessage('Email verified successfully! Your request is now pending admin approval.');

--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -48,25 +48,23 @@ export default function SignupForm({ onSuccess, onCancel }: SignupFormProps) {
 
     try {
       // Step 1: Send email verification request (no Firebase auth yet)
-      const response = await apiFetch('/api/signup/request-verification', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
+      const data = await apiFetch<{ emailSent: boolean }>(
+        '/api/signup/request-verification',
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            firstName: firstName.trim(),
+            email: email.trim(),
+            siteId: getSiteId(),
+          }),
         },
-        body: JSON.stringify({
-          firstName: firstName.trim(),
-          email: email.trim(),
-          siteId: getSiteId()
-        })
-      });
+      );
 
-      const data = await response.json();
-
-      if (response.ok) {
-        setIsSubmitted(true);
-      } else {
-        setError('לא ניתן להירשם כרגע. נסה שוב מאוחר יותר.');
-      }
+      setIsSubmitted(true);
+      setEmailSent(data.emailSent ?? false);
     } catch (error) {
       console.error('Signup error:', error);
       setError('Failed to send verification email. Please try again.');

--- a/src/entities/User.ts
+++ b/src/entities/User.ts
@@ -11,11 +11,10 @@ export interface IUser {
 export class User {
   static async me(): Promise<IUser | null> {
     try {
-      const res = await apiFetch('/api/auth/me');
-
-      return res as IUser;
+      const res = await apiFetch<IUser>('/api/auth/me');
+      return res;
     } catch {
       return null;
     }
   }
-} 
+}

--- a/src/store/UserStore.ts
+++ b/src/store/UserStore.ts
@@ -41,7 +41,7 @@ export const useUserStore = create<UserState>((set, get) => ({
     }
   },
   logout: async () => {
-    await apiFetch('/api/auth/logout', { method: 'POST', credentials: 'include' });
+    await apiFetch<void>('/api/auth/logout', { method: 'POST', credentials: 'include' });
     set({ user: null });
     const memberStore = useMemberStore.getState();
     memberStore.clearMember();


### PR DESCRIPTION
## Summary
- Use `apiFetch` with generics and remove manual `.ok`/`.json()` handling
- Simplify server interaction across components and stores

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a616fb07f083279c9597b513bba981