### PR TITLE
Add member home and public landing flow

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import React from 'react';
+import WelcomeHero from '../../components/home/WelcomeHero';
+import FamilyOverview from '../../components/FamilyOverview';
+import { useUserStore } from '../../store/UserStore';
+
+export default function MemberHome() {
+  const { user, loading } = useUserStore();
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sage-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen">
+      <WelcomeHero user={user} />
+      <FamilyOverview />
+    </div>
+  );
+}
+

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -45,7 +45,7 @@ export default function LoginPage() {
           user_id: result.user.uid,
         });
 
-        await router.replace('/');
+        await router.replace('/home');
       }
     } catch (e) {
       setError(t('googleLoginFailed'));
@@ -74,7 +74,7 @@ export default function LoginPage() {
           user_id: result.user.uid
         });
 
-        router.push("/");
+        router.push('/home');
       }
     } catch (error: any) {
       if (error.code === 'auth/user-not-found' || error.code === 'auth/wrong-password') {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,24 @@
 'use client';
 
-import React from "react";
+import React, { useEffect } from "react";
+import { useRouter } from "next/navigation";
 import WelcomeHero from "../components/home/WelcomeHero";
 import FamilyOverview from "../components/FamilyOverview";
-import {useUserStore} from "../store/UserStore";
-import {useTranslation} from 'react-i18next';
+import { useUserStore } from "../store/UserStore";
+import { useTranslation } from 'react-i18next';
 
-export default function Home() {
-    const {t} = useTranslation();
-    const {user, loading} = useUserStore();
+export default function LandingPage() {
+    const { t } = useTranslation();
+    const { user, loading } = useUserStore();
+    const router = useRouter();
 
-    if (loading) {
+    useEffect(() => {
+        if (!loading && user) {
+            router.replace('/home');
+        }
+    }, [loading, user, router]);
+
+    if (loading || user) {
         return (
             <div className="min-h-screen flex items-center justify-center">
                 <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-sage-600"></div>
@@ -20,8 +28,8 @@ export default function Home() {
 
     return (
         <div className="min-h-screen">
-            <WelcomeHero user={user} title={t('welcomeToFamilyCircle')} subtitle={t('stayConnected')}/>
-            <FamilyOverview/>
+            <WelcomeHero user={user} title={t('welcomeToFamilyCircle')} subtitle={t('stayConnected')} />
+            <FamilyOverview />
         </div>
     );
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -43,7 +43,7 @@ export default function Navigation({ user, onLogout, setMobileMenuOpen }: Naviga
   }, [isMobileMenuOpen, setMobileMenuOpen]);
 
   const navigationItems = [
-    { name: t('home'), href: '/', icon: Home },
+    { name: t('home'), href: '/home', icon: Home },
     { name: t('family'), href: '/family', icon: Users },
     { name: t('activities'), href: '/activities', icon: Heart },
     { name: t('anniversaries'), href: '/anniversaries', icon: Calendar },

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,7 @@ import { apiFetchFromMiddlewareJSON, verifyAccessToken } from 'src/lib/edgeAuth'
 import { NextRequest, NextResponse } from 'next/server';
 
 const PUBLIC_PATHS = [
+  '/',
   '/login',
   '/contact',
   '/favicon.ico',


### PR DESCRIPTION
## Summary
- Allow anonymous access to landing page by adding `/` to middleware `PUBLIC_PATHS`
- Introduce authenticated member home page at `/home`
- Redirect logged in users and navigation to `/home`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a783da0f0483279da386417a067e42