### PR TITLE
feat: create user guard

### DIFF
--- a/src/app/api/user/[id]/member-info/route.ts
+++ b/src/app/api/user/[id]/member-info/route.ts
@@ -1,5 +1,5 @@
 import { FamilyRepository } from '@/repositories/FamilyRepository';
-import { withMemberGuard } from "@/lib/withMemberGuard";
+import { withUserGuard } from "@/lib/withUserGuard";
 import { GuardContext } from '@/app/api/types';
 
 export const dynamic = 'force-dynamic';
@@ -23,4 +23,4 @@ const handler = async (request: Request, context: GuardContext) => {
   }
 };
 
-export const GET = withMemberGuard(handler);
+export const GET = withUserGuard(handler);

--- a/src/lib/withUserGuard.ts
+++ b/src/lib/withUserGuard.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { ACCESS_TOKEN } from '@/auth/cookies';
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/auth/service';
+import { RouteHandler, GuardContext } from '../app/api/types';
+
+let getCookies = cookies;
+
+export function __setMockCookies(fn: typeof cookies) {
+  getCookies = fn;
+}
+
+export function withUserGuard(handler: RouteHandler): RouteHandler {
+  return async (request: Request, context: GuardContext) => {
+    try {
+      const cookieStore = getCookies();
+      const token = cookieStore.get(ACCESS_TOKEN)?.value;
+      const payload = token && verifyAccessToken(token);
+      if (!payload) {
+        return NextResponse.json({ error: 'Unauthorized (withUG)' }, { status: 401 });
+      }
+      context.user = payload;
+      return handler(request, context);
+    } catch (error) {
+      console.error(error);
+      return NextResponse.json({ error: 'Unauthorized (withUG, error)' }, { status: 401 });
+    }
+  };
+}

--- a/tests/withUserGuard.test.ts
+++ b/tests/withUserGuard.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import { signAccessToken } from '../src/auth/service';
+import { NextResponse } from 'next/server.js';
+
+const { privateKey, publicKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+process.env.JWT_PRIVATE_KEY = privateKey.export({ type: 'pkcs1', format: 'pem' }).toString();
+process.env.JWT_PUBLIC_KEY = publicKey.export({ type: 'pkcs1', format: 'pem' }).toString();
+
+const claims = {
+  userId: 'user1',
+  siteId: 'site1',
+  role: 'member',
+  firstName: 'Test',
+  lastName: 'User',
+};
+
+let withUserGuard: any;
+let __setMockCookies: any;
+
+async function testExpiredToken() {
+  const token = signAccessToken(claims, -5);
+  __setMockCookies(() => ({ get: () => ({ value: token }) }));
+  let called = false;
+  const handler = () => { called = true; return NextResponse.json({ ok: true }); };
+  const guarded = withUserGuard(handler);
+  const res = await guarded(new Request('https://example.com'), {} as any);
+  assert.equal(res.status, 401);
+  const data = await res.json();
+  assert.equal(data.error, 'Unauthorized (withUG)');
+  assert.equal(called, false);
+  console.log('expired token test passed');
+}
+
+async function testValidToken() {
+  const token = signAccessToken(claims);
+  __setMockCookies(() => ({ get: () => ({ value: token }) }));
+  let called = false;
+  let capturedUser: any;
+  const handler = (_req: Request, ctx: any) => {
+    called = true;
+    capturedUser = ctx.user;
+    return NextResponse.json({ ok: true });
+  };
+  const guarded = withUserGuard(handler);
+  const res = await guarded(new Request('https://example.com'), {} as any);
+  assert.equal(res.status, 200);
+  const data = await res.json();
+  assert.equal(data.ok, true);
+  assert.equal(called, true);
+  assert.equal(capturedUser.userId, 'user1');
+  console.log('valid token test passed');
+}
+
+async function run() {
+  const mod = await import('../src/lib/withUserGuard');
+  withUserGuard = mod.withUserGuard;
+  __setMockCookies = mod.__setMockCookies;
+  await testExpiredToken();
+  await testValidToken();
+}
+
+run();


### PR DESCRIPTION
## Summary
- add withUserGuard to authenticate users without requiring membership
- use withUserGuard for `/api/user/[id]/member-info` endpoint
- test token handling for withUserGuard

## Testing
- `npm test`
- `npx tsx tests/withMemberGuard.test.ts`
- `npx tsx tests/withUserGuard.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68aa007e080c8327b46f6c33e52173c3