### PR TITLE
Redirect to login when authentication fails

### DIFF
--- a/src/app/auth-gate/page.tsx
+++ b/src/app/auth-gate/page.tsx
@@ -5,7 +5,6 @@ import { useRouter } from 'next/navigation';
 import { useSiteStore } from "@/store/SiteStore";
 import { useMemberStore } from "@/store/MemberStore";
 import { useUserStore } from "@/store/UserStore";
-import { landingPage } from "@/app/settings";
 
 export default function AuthGate() {
   const router = useRouter();
@@ -30,10 +29,11 @@ export default function AuthGate() {
           if (u?.user_id && siteId) await fetchMember(u.user_id, siteId);
           router.replace(originalUrl);
         } else {
-          router.replace(landingPage);
+          router.replace('/app?login=1');
         }
-      } catch {
-        router.replace(landingPage);
+      } catch (err) {
+        router.replace('/app?login=1');
+        throw err;
       }
     })();
   }, [router]);

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -21,13 +21,20 @@ export default function ClientLayoutShell({ children }) {
   const member = useMemberStore((state) => state.member);
   const router = useRouter();
   const { t, i18n } = useTranslation();
-  const { isOpen: isLoginOpen, close: closeLogin } = useLoginModalStore();
+  const { isOpen: isLoginOpen, close: closeLogin, open: openLogin } = useLoginModalStore();
 
   const { fetchMember } = useMemberStore();
 
   useEffect(() => {
-    checkAuth();
-  }, [checkAuth])
+    checkAuth()
+      .then(() => {
+        if (!useUserStore.getState().user) openLogin();
+      })
+      .catch((err) => {
+        openLogin();
+        throw err;
+      });
+  }, [checkAuth, openLogin]);
 
   useEffect(() => {
     if (!user?.user_id || !siteInfo?.id) return;

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React from "react";
+import React, { useEffect } from "react";
+import { useSearchParams } from 'next/navigation';
 import WelcomeHero from "./WelcomeHero";
 import FamilyOverview from "../FamilyOverview";
 import { useUserStore } from "@/store/UserStore";
@@ -11,6 +12,13 @@ export default function Home() {
     const { t } = useTranslation();
     const { user, loading } = useUserStore();
     const openLogin = useLoginModalStore((s) => s.open);
+    const searchParams = useSearchParams();
+
+    useEffect(() => {
+        if (searchParams.get('login') === '1') {
+            openLogin();
+        }
+    }, [searchParams, openLogin]);
 
     if (loading) {
         return (


### PR DESCRIPTION
## Summary
- Open login modal if auth check completes without a user
- Redirect failed refresh attempts to `/app?login=1`
- Trigger login modal when `login=1` query is present on `/app`

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1a787acc8327aa8724b2becfca69