### PR TITLE
Add public header and layout i18n integration

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,3 +1,56 @@
-export default function PublicLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+import '../globals.css';
+import I18nProvider from '../../components/I18nProvider';
+import I18nGate from '../../components/I18nGate';
+import PublicHeader from '../../components/PublicHeader';
+import { fetchSiteInfo } from '../../firebase/admin';
+
+export default async function PublicLayout({ children }: { children: React.ReactNode }) {
+  let siteInfo = null;
+  try {
+    siteInfo = await fetchSiteInfo();
+  } catch (error) {
+    console.error('Failed to fetch site info:', error);
+    throw error;
+  }
+
+  return (
+    <I18nProvider>
+      <I18nGate>
+        <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50">
+          <style>{`
+            :root {
+              --cream-50: #FEFCF8;
+              --cream-100: #FDF8F0;
+              --sage-50: #F7F8F6;
+              --sage-100: #E8EBE6;
+              --sage-200: #D1D8CC;
+              --sage-300: #A8B5A0;
+              --sage-400: #8B9A7B;
+              --sage-500: #6B7A5E;
+              --sage-600: #566249;
+              --sage-700: #454F3B;
+              --sage-800: #373F2F;
+              --sage-900: #2C3E36;
+              --charcoal: #2C3E36;
+            }
+            .bg-cream-50 { background-color: var(--cream-50); }
+            .bg-cream-100 { background-color: var(--cream-100); }
+            .bg-sage-50 { background-color: var(--sage-50); }
+            .bg-sage-100 { background-color: var(--sage-100); }
+            .bg-sage-600 { background-color: var(--sage-600); }
+            .bg-sage-700 { background-color: var(--sage-700); }
+            .text-sage-600 { color: var(--sage-600); }
+            .text-sage-700 { color: var(--sage-700); }
+            .text-charcoal { color: var(--charcoal); }
+            .border-sage-200 { border-color: var(--sage-200); }
+            .border-sage-600 { border-color: var(--sage-600); }
+            .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
+            .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
+          `}</style>
+          <PublicHeader siteInfo={siteInfo} />
+          {children}
+        </div>
+      </I18nGate>
+    </I18nProvider>
+  );
 }

--- a/src/components/PublicHeader.tsx
+++ b/src/components/PublicHeader.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ISite } from '@/entities/Site';
+
+const LANGS = [
+  { code: 'he', label: 'עברית', flag: '🇮🇱' },
+  { code: 'en', label: 'English', flag: '🇬🇧' },
+  { code: 'tr', label: 'Türkçe', flag: '🇹🇷' },
+];
+
+export default function PublicHeader({ siteInfo }: { siteInfo: ISite }) {
+  const { i18n } = useTranslation();
+  const [isLangMenuOpen, setIsLangMenuOpen] = useState(false);
+
+  const handleLangChange = (lang: string) => {
+    if (i18n.language !== lang) {
+      i18n.changeLanguage(lang);
+    }
+    setIsLangMenuOpen(false);
+  };
+
+  const menuPosition = i18n.language === 'he' ? 'left-0' : 'right-0';
+
+  return (
+    <header className="w-full flex items-center justify-between px-4 py-2 bg-white shadow-sm sticky top-0 z-50">
+      <div className="text-xl font-semibold text-sage-700">
+        {siteInfo.name}
+      </div>
+      <div className="relative">
+        <button
+          onClick={() => setIsLangMenuOpen(v => !v)}
+          className="h-8 w-8 rounded-full flex items-center justify-center text-xl bg-gray-100 hover:bg-gray-200 border border-gray-300"
+          aria-label="Change language"
+        >
+          {LANGS.find(l => l.code === i18n.language)?.flag || '🌐'}
+        </button>
+        {isLangMenuOpen && (
+          <div className={`language-menu ${menuPosition}`}>
+            <div className="py-1 flex flex-col">
+              {LANGS.map(({ code, label, flag }) => (
+                <button
+                  key={code}
+                  onClick={() => handleLangChange(code)}
+                  className={`language-menu-item ${i18n.language === code ? 'font-bold' : ''}`}
+                >
+                  <span>{flag}</span>
+                  <span>{label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add `PublicHeader` component with language selector and site title
- render header and i18n providers in public layout

## Testing
- `npm test`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68aa29219d108327a9cfd7bf9a753d37