### PR TITLE
Fix build errors by initializing i18n and delaying Firebase admin

### DIFF
--- a/src/app/admin/pending-members/page.tsx
+++ b/src/app/admin/pending-members/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
 import React, { useState, useEffect } from 'react';
 import { Card, CardContent } from '@/components/ui/card';

--- a/src/app/anniversaries/page.tsx
+++ b/src/app/anniversaries/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
 import { useEffect, useRef, useState, ChangeEvent } from 'react';
 import Modal from '@/components/ui/Modal';
@@ -43,7 +44,7 @@ export default function AnniversariesPage() {
   const [imageFile, setImageFile] = useState<File | null>(null);
   const user = useUserStore((s) => s.user);
   const member = useMemberStore((state) => state.member);
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const [imageSrc, setImageSrc] = useState('');
   const [offsetY, setOffsetY] = useState(0);
@@ -222,11 +223,11 @@ export default function AnniversariesPage() {
         className={`border p-2 h-32 rounded-xl shadow-md transition-colors relative overflow-hidden ${
           isCurrentMonth ? 'hover:bg-emerald-50' : 'text-gray-400 bg-gray-50'
         }`}
-        dir={document.documentElement.dir}
+        dir={i18n.dir()}
       >
         <div
           className={`absolute top-1 ${
-            document.documentElement.dir === 'rtl' ? 'right-1' : 'left-1'
+            i18n.dir() === 'rtl' ? 'right-1' : 'left-1'
           } flex items-center`}
         >
           <span className="font-bold text-sm">{cellDay}</span>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,15 @@
 import './globals.css';
+import I18nProvider from '../components/I18nProvider';
+import I18nGate from '../components/I18nGate';
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <I18nProvider>
+          <I18nGate>{children}</I18nGate>
+        </I18nProvider>
+      </body>
     </html>
   );
 }

--- a/src/app/pending-member/page.tsx
+++ b/src/app/pending-member/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const dynamic = 'force-dynamic';
 
 import React from 'react';
 import { Clock, CheckCircle, AlertCircle } from 'lucide-react';

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,10 +4,13 @@ import HttpBackend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import nextI18NextConfig from '../next-i18next.config.js';
 
+const isBrowser = typeof window !== 'undefined';
+
 if (!i18n.isInitialized) {
+  if (isBrowser) {
+    i18n.use(HttpBackend).use(LanguageDetector);
+  }
   i18n
-    .use(HttpBackend)
-    .use(LanguageDetector)
     .use(initReactI18next)
     .init({
       ...nextI18NextConfig.i18n,

--- a/src/lib/withMemberGuard.ts
+++ b/src/lib/withMemberGuard.ts
@@ -3,12 +3,11 @@ import { ACCESS_TOKEN } from '@/auth/cookies';
 import { cookies } from 'next/headers';
 import { verifyAccessToken } from '@/auth/service';
 import { initAdmin } from '@/firebase/admin';
-import { getFirestore } from 'firebase-admin/firestore';
+import { getFirestore, Firestore } from 'firebase-admin/firestore';
 import { RouteHandler, GuardContext } from '../app/api/types';
 import { memberConverter } from '../entities/firebase/MemberDoc';
 
-initAdmin();
-let db = getFirestore();
+let db: Firestore | null = null;
 let getCookies = cookies;
 
 export function __setMockCookies(fn: typeof cookies) {
@@ -22,6 +21,10 @@ export function __setMockDb(mockDb: any) {
 export function withMemberGuard(handler: RouteHandler): RouteHandler {
   return async (request: Request, context: GuardContext) => {
     try {
+      if (!db) {
+        initAdmin();
+        db = getFirestore();
+      }
       const cookieStore = getCookies();
       const token = cookieStore.get(ACCESS_TOKEN)?.value;
       const payload = token && verifyAccessToken(token);


### PR DESCRIPTION
## Summary
- Lazily initialize Firebase admin in member guard
- Initialize i18n only in browser and wrap root layout with provider
- Mark client pages as dynamic and rely on i18n direction helpers

## Testing
- `CI=1 npx next build`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68aa2ff4068883279d9faf4900fda565