### PR TITLE
sanitize site info timestamps for client components

### DIFF
--- a/src/firebase/admin.ts
+++ b/src/firebase/admin.ts
@@ -1,6 +1,6 @@
 import { initializeApp, cert, getApps } from 'firebase-admin/app';
 import { getAuth } from 'firebase-admin/auth';
-import { getFirestore } from 'firebase-admin/firestore';
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
 
 export function initAdmin() {
   if (!getApps().length) {
@@ -24,5 +24,17 @@ export async function fetchSiteInfo() {
   }
   const siteId = process.env.NEXT_SITE_ID;
   const doc = await db.collection('sites').doc(siteId).get();
-  return doc.exists ? { id: doc.id, ...doc.data() } : null;
+  if (!doc.exists) return null;
+
+  const data = doc.data() || {};
+  const plainData: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value instanceof Timestamp) {
+      plainData[key] = value.toDate().toISOString();
+    } else {
+      plainData[key] = value;
+    }
+  }
+
+  return { id: doc.id, ...plainData };
 }


### PR DESCRIPTION
## Summary
- ensure Firebase siteInfo data contains only plain values before passing to client components

## Testing
- `timeout 15 npx tsc >/tmp/tsc.log && cat /tmp/tsc.log | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68aa99ff8fcc8327af840e0f3b410e12