### PR TITLE
Move site info injection to root layout

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,39 +1,14 @@
-import '../globals.css';
 import ClientLayoutShell from '../../components/ClientLayoutShell';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
-import { fetchSiteInfo } from '../../firebase/admin';
 import { headers } from 'next/headers';
 
-export default async function RootLayout({ children }) {
-  let siteInfo = null;
+export default function RootLayout({ children }) {
   const h = headers();
   const isAuthGate = h.get('x-auth-gate') === '1';
 
-  try {
-    if (!isAuthGate) siteInfo = await fetchSiteInfo();
-  } catch (error) {
-    console.error('Failed to fetch site info:', error);
-    throw error;
-  }
-
   return (
-    <html lang="en">
-      <body>
-        {/* Inject siteInfo as a global variable for client-side hydration */}
-        <script
-          id="__SITE_INFO__"
-          dangerouslySetInnerHTML={{
-            __html: `window.__SITE_INFO__=${JSON.stringify(siteInfo || {})};`,
-          }}
-        />
-        <ErrorBoundary>{
-          isAuthGate ? <>{children}</> :
-          <ClientLayoutShell>
-            {children}
-          </ClientLayoutShell>
-        }
-        </ErrorBoundary>
-      </body>
-    </html>
+    <ErrorBoundary>
+      {isAuthGate ? <>{children}</> : <ClientLayoutShell>{children}</ClientLayoutShell>}
+    </ErrorBoundary>
   );
 }

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,6 +1,3 @@
-import '../globals.css';
-import I18nProvider from '../../components/I18nProvider';
-import I18nGate from '../../components/I18nGate';
 import PublicLayoutShell from '../../components/PublicLayoutShell';
 import { fetchSiteInfo } from '../../firebase/admin';
 
@@ -13,18 +10,5 @@ export default async function PublicLayout({ children }: { children: React.React
     throw error;
   }
 
-  return (
-    <I18nProvider>
-      <I18nGate>
-        {/* Inject siteInfo for client-side access */}
-        <script
-          id="__SITE_INFO__"
-          dangerouslySetInnerHTML={{
-            __html: `window.__SITE_INFO__=${JSON.stringify(siteInfo || {})};`,
-          }}
-        />
-        <PublicLayoutShell siteInfo={siteInfo}>{children}</PublicLayoutShell>
-      </I18nGate>
-    </I18nProvider>
-  );
+  return <PublicLayoutShell siteInfo={siteInfo}>{children}</PublicLayoutShell>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,27 @@
 import './globals.css';
 import I18nProvider from '../components/I18nProvider';
 import I18nGate from '../components/I18nGate';
+import { fetchSiteInfo } from '../firebase/admin';
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  let siteInfo = null;
+  try {
+    siteInfo = await fetchSiteInfo();
+  } catch (error) {
+    console.error('Failed to fetch site info:', error);
+    throw error;
+  }
+
   return (
     <html lang="en">
       <body>
+        {/* Inject siteInfo for client-side access */}
+        <script
+          id="__SITE_INFO__"
+          dangerouslySetInnerHTML={{
+            __html: `window.__SITE_INFO__=${JSON.stringify(siteInfo || {})};`,
+          }}
+        />
         <I18nProvider>
           <I18nGate>{children}</I18nGate>
         </I18nProvider>


### PR DESCRIPTION
## Summary
- inject site info script from root layout so it is available on all pages
- remove extra `<html>` wrappers and redundant site-info scripts from route layouts

## Testing
- `npx tsc --noEmit`
- `npx next build` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_68ab310fe4908327a468c47a8c40105c