### PR TITLE
Display pending membership modal on /app

### DIFF
--- a/src/app/pending-member/page.tsx
+++ b/src/app/pending-member/page.tsx
@@ -2,54 +2,12 @@
 export const dynamic = 'force-dynamic';
 
 import React from 'react';
-import { Clock, CheckCircle, AlertCircle } from 'lucide-react';
-import Link from 'next/link';
-import { Button } from '@/components/ui/button';
-import { useRouter } from 'next/navigation';
-import { useTranslation } from 'react-i18next';
-import { apiFetch } from '@/utils/apiFetch';
-import { landingPage } from "@/app/settings";
+import PendingMemberContent from '@/components/PendingMemberContent';
 
 export default function PendingMemberPage() {
-  const { t, i18n } = useTranslation();
-  const router = useRouter();
-
-  const handleLogout = async () => {
-    await apiFetch<void>('/api/auth/logout', { method: 'POST' });
-    router.push(landingPage);
-  };
-
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50" dir={i18n.dir()} lang={i18n.language}>
-      <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 text-center space-y-4">
-        <div className="mx-auto mb-4">
-          <Clock className="w-16 h-16 text-yellow-500" />
-        </div>
-        <h2 className="text-xl font-bold text-gray-900">{t('pendingApprovalTitle')}</h2>
-        <p className="text-gray-600">{t('pendingApprovalMessage')}</p>
-        <p className="text-gray-600">{t('pendingApprovalNotify')}</p>
-
-        <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
-          <div className="flex items-center gap-2 text-blue-800">
-            <CheckCircle className="w-5 h-5" />
-            <span className="text-sm font-medium">{t('pendingApprovalRequestSent')}</span>
-          </div>
-        </div>
-
-        <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-          <div className="flex items-center gap-2 text-yellow-800">
-            <AlertCircle className="w-5 h-5" />
-            <span className="text-sm font-medium">{t('pendingApprovalWaitingAdmin')}</span>
-          </div>
-        </div>
-
-        <div className="flex flex-col gap-3 mt-8">
-          <Link href="/contact" passHref legacyBehavior>
-            <Button className="w-full bg-black text-white rounded hover:bg-gray-800">{t('contactUs')}</Button>
-          </Link>
-          <Button className="w-full bg-gray-200 text-gray-800 rounded hover:bg-gray-300" onClick={handleLogout} type="button">{t('logout')}</Button>
-        </div>
-      </div>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <PendingMemberContent />
     </div>
   );
 }

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -13,6 +13,8 @@ import { landingPage } from "@/app/settings";
 import Modal from '@/components/ui/Modal';
 import LoginPage from '@/components/LoginPage';
 import { useLoginModalStore } from '@/store/LoginModalStore';
+import PendingMemberContent from '@/components/PendingMemberContent';
+import { usePendingMemberModalStore } from '@/store/PendingMemberModalStore';
 
 export default function ClientLayoutShell({ children }) {
   const { user, loading, logout, checkAuth } = useUserStore();
@@ -22,6 +24,7 @@ export default function ClientLayoutShell({ children }) {
   const router = useRouter();
   const { t, i18n } = useTranslation();
   const { isOpen: isLoginOpen, close: closeLogin, open: openLogin } = useLoginModalStore();
+  const { isOpen: isPendingOpen, close: closePending, open: openPending } = usePendingMemberModalStore();
 
   const { fetchMember } = useMemberStore();
 
@@ -41,9 +44,9 @@ export default function ClientLayoutShell({ children }) {
 
     (async () => {
       const ok = await fetchMember(user.user_id, siteInfo.id);
-      if (!ok) router.replace("/pending-member");
+      if (!ok && !useMemberStore.getState().error) openPending();
     })();
-  }, [user?.user_id, siteInfo?.id, fetchMember, router]);
+  }, [user?.user_id, siteInfo?.id, fetchMember, openPending]);
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -125,6 +128,9 @@ export default function ClientLayoutShell({ children }) {
           {children}
           <Modal isOpen={isLoginOpen} onClose={closeLogin}>
             <LoginPage/>
+          </Modal>
+          <Modal isOpen={isPendingOpen} onClose={closePending}>
+            <PendingMemberContent/>
           </Modal>
         </div>
       </I18nGate>

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -11,6 +11,7 @@ import { useUserStore } from '@/store/UserStore';
 import { useLoginModalStore } from '@/store/LoginModalStore';
 import SignupForm from '@/components/SignupForm';
 import { useTranslation } from 'react-i18next';
+import { usePendingMemberModalStore } from '@/store/PendingMemberModalStore';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -23,6 +24,7 @@ export default function LoginPage() {
   const { setUser } = useUserStore();
   const { t } = useTranslation();
   const { close: closeLogin } = useLoginModalStore();
+  const { open: openPending } = usePendingMemberModalStore();
 
   const handleGoogleLogin = async () => {
     try {
@@ -122,7 +124,10 @@ export default function LoginPage() {
   if (showSignup) {
     return (
       <SignupForm
-        onSuccess={() => router.push('/pending-member')}
+        onSuccess={() => {
+          closeLogin();
+          openPending();
+        }}
         onCancel={() => setShowSignup(false)}
       />
     );

--- a/src/components/PendingMemberContent.tsx
+++ b/src/components/PendingMemberContent.tsx
@@ -1,0 +1,51 @@
+'use client';
+import React from 'react';
+import { Clock, CheckCircle, AlertCircle } from 'lucide-react';
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { useRouter } from 'next/navigation';
+import { useTranslation } from 'react-i18next';
+import { apiFetch } from '@/utils/apiFetch';
+import { landingPage } from '@/app/settings';
+
+export default function PendingMemberContent() {
+  const { t, i18n } = useTranslation();
+  const router = useRouter();
+
+  const handleLogout = async () => {
+    await apiFetch<void>('/api/auth/logout', { method: 'POST' });
+    router.push(landingPage);
+  };
+
+  return (
+    <div className="w-full max-w-md bg-white rounded-2xl shadow-xl p-8 text-center space-y-4" dir={i18n.dir()} lang={i18n.language}>
+      <div className="mx-auto mb-4">
+        <Clock className="w-16 h-16 text-yellow-500" />
+      </div>
+      <h2 className="text-xl font-bold text-gray-900">{t('pendingApprovalTitle')}</h2>
+      <p className="text-gray-600">{t('pendingApprovalMessage')}</p>
+      <p className="text-gray-600">{t('pendingApprovalNotify')}</p>
+
+      <div className="mt-6 p-4 bg-blue-50 border border-blue-200 rounded-lg">
+        <div className="flex items-center gap-2 text-blue-800">
+          <CheckCircle className="w-5 h-5" />
+          <span className="text-sm font-medium">{t('pendingApprovalRequestSent')}</span>
+        </div>
+      </div>
+
+      <div className="mt-4 p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+        <div className="flex items-center gap-2 text-yellow-800">
+          <AlertCircle className="w-5 h-5" />
+          <span className="text-sm font-medium">{t('pendingApprovalWaitingAdmin')}</span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3 mt-8">
+        <Link href="/contact" passHref legacyBehavior>
+          <Button className="w-full bg-black text-white rounded hover:bg-gray-800">{t('contactUs')}</Button>
+        </Link>
+        <Button className="w-full bg-gray-200 text-gray-800 rounded hover:bg-gray-300" onClick={handleLogout} type="button">{t('logout')}</Button>
+      </div>
+    </div>
+  );
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -10,6 +10,7 @@ const PUBLIC_PATHS = [
   '/_next',
   '/locales',
   '/auth-gate',
+  '/app',
 ];
 
 export async function middleware(request: NextRequest) {

--- a/src/store/MemberStore.ts
+++ b/src/store/MemberStore.ts
@@ -20,14 +20,16 @@ export const useMemberStore = create<MemberState>((set, get) => ({
     try {
       set({ loading: true, error: null });
 
-      const data =await apiFetch<{ member: IMember }>(`/api/user/${userId}/member-info?siteId=${siteId}`);
+      const data = await apiFetch<{ member: IMember }>(`/api/user/${userId}/member-info?siteId=${siteId}`);
       set({ member: data.member, loading: false });
       return true;
     } catch (error) {
-      set({
-        error: error instanceof Error ? error.message : 'Failed to fetch member info',
-        loading: false 
-      });
+      const message = error instanceof Error ? error.message : 'Failed to fetch member info';
+      if (message.startsWith('HTTP 404')) {
+        set({ member: null, loading: false, error: null });
+      } else {
+        set({ error: message, loading: false });
+      }
     }
     return false;
   },

--- a/src/store/PendingMemberModalStore.ts
+++ b/src/store/PendingMemberModalStore.ts
@@ -1,0 +1,14 @@
+'use client';
+import { create } from 'zustand';
+
+interface PendingMemberModalStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const usePendingMemberModalStore = create<PendingMemberModalStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- Add modal and store for pending membership notice
- Fetch member info and open pending modal when 404
- Treat `/app` as public path to avoid redirect

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68ab37f961c4832796f045cc250a8ba8