### PR TITLE
feat: add layout footer component

### DIFF
--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -5,6 +5,7 @@ import { useUserStore } from '../store/UserStore';
 import { useRouter } from "next/navigation";
 import { useMemberStore } from '../store/MemberStore';
 import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 import I18nProvider from './I18nProvider';
 import { useTranslation } from 'react-i18next';
 import { Loader } from "../components/ui/Loader";
@@ -126,6 +127,7 @@ export default function ClientLayoutShell({ children }) {
             />
           ) : null}
           {children}
+          {siteInfo ? <Footer siteInfo={siteInfo} /> : null}
           <Modal isOpen={isLoginOpen} onClose={closeLogin}>
             <LoginPage/>
           </Modal>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,16 @@
+"use client";
+import React from "react";
+import { ISite } from "@/entities/Site";
+
+interface FooterProps {
+  siteInfo: ISite;
+}
+
+export default function Footer({ siteInfo }: FooterProps) {
+  const year = new Date().getFullYear();
+  return (
+    <footer className="w-full px-4 py-6 text-center text-sm text-sage-700 border-t border-sage-200">
+      <p>&copy; {year} {siteInfo.name}. All rights reserved.</p>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add footer component displaying site name and year
- include footer in client layout after children

## Testing
- `npx tsc`
- `npx next build` *(fails: Service account object must contain a string "private_key" property.)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5835a2588327bbda909a325cbb1b