### PR TITLE
refactor layout to include header and footer

### DIFF
--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,14 +1,5 @@
-import ClientLayoutShell from '../../components/ClientLayoutShell';
 import { ErrorBoundary } from '../../components/ErrorBoundary';
-import { headers } from 'next/headers';
 
 export default function RootLayout({ children }) {
-  const h = headers();
-  const isAuthGate = h.get('x-auth-gate') === '1';
-
-  return (
-    <ErrorBoundary>
-      {isAuthGate ? <>{children}</> : <ClientLayoutShell>{children}</ClientLayoutShell>}
-    </ErrorBoundary>
-  );
+  return <ErrorBoundary>{children}</ErrorBoundary>;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import './globals.css';
 import I18nProvider from '../components/I18nProvider';
 import I18nGate from '../components/I18nGate';
 import { fetchSiteInfo } from '../firebase/admin';
+import Header from '@/components/Header';
+import Footer from '@/components/Footer';
+import ClientLayoutShell from '@/components/ClientLayoutShell';
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   let siteInfo = null;
@@ -23,7 +26,44 @@ export default async function RootLayout({ children }: { children: React.ReactNo
           }}
         />
         <I18nProvider>
-          <I18nGate>{children}</I18nGate>
+          <I18nGate>
+            <ClientLayoutShell />
+            <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50">
+              <style>{`
+          :root {
+            --cream-50: #FEFCF8;
+            --cream-100: #FDF8F0;
+            --sage-50: #F7F8F6;
+            --sage-100: #E8EBE6;
+            --sage-200: #D1D8CC;
+            --sage-300: #A8B5A0;
+            --sage-400: #8B9A7B;
+            --sage-500: #6B7A5E;
+            --sage-600: #566249;
+            --sage-700: #454F3B;
+            --sage-800: #373F2F;
+            --sage-900: #2C3E36;
+            --charcoal: #2C3E36;
+          }
+          .bg-cream-50 { background-color: var(--cream-50); }
+          .bg-cream-100 { background-color: var(--cream-100); }
+          .bg-sage-50 { background-color: var(--sage-50); }
+          .bg-sage-100 { background-color: var(--sage-100); }
+          .bg-sage-600 { background-color: var(--sage-600); }
+          .bg-sage-700 { background-color: var(--sage-700); }
+          .text-sage-600 { color: var(--sage-600); }
+          .text-sage-700 { color: var(--sage-700); }
+          .text-charcoal { color: var(--charcoal); }
+          .border-sage-200 { border-color: var(--sage-200); }
+          .border-sage-600 { border-color: var(--sage-600); }
+          .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
+          .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
+        `}</style>
+              <Header />
+              {children}
+              <Footer />
+            </div>
+          </I18nGate>
         </I18nProvider>
       </body>
     </html>

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -1,31 +1,23 @@
 'use client';
-import React, { useState, useEffect } from "react";
+import React, { useEffect } from "react";
 import { useSiteStore } from '../store/SiteStore';
 import { useUserStore } from '../store/UserStore';
-import { useRouter } from "next/navigation";
 import { useMemberStore } from '../store/MemberStore';
-import Header from "@/components/Header";
-import I18nProvider from './I18nProvider';
 import { useTranslation } from 'react-i18next';
 import { Loader } from "../components/ui/Loader";
-import I18nGate from "@/components/I18nGate";
-import { landingPage } from "@/app/settings";
 import Modal from '@/components/ui/Modal';
 import LoginPage from '@/components/LoginPage';
 import { useLoginModalStore } from '@/store/LoginModalStore';
 import PendingMemberContent from '@/components/PendingMemberContent';
 import { usePendingMemberModalStore } from '@/store/PendingMemberModalStore';
 
-export default function ClientLayoutShell({ children }) {
-  const { user, loading, logout, checkAuth } = useUserStore();
+export default function ClientLayoutShell() {
+  const { user, loading, checkAuth } = useUserStore();
   const setSiteInfo = useSiteStore((state) => state.setSiteInfo);
   const siteInfo = useSiteStore((state) => state.siteInfo);
-  const member = useMemberStore((state) => state.member);
-  const router = useRouter();
-  const { t, i18n } = useTranslation();
+  const { i18n } = useTranslation();
   const { isOpen: isLoginOpen, close: closeLogin, open: openLogin } = useLoginModalStore();
   const { isOpen: isPendingOpen, close: closePending, open: openPending } = usePendingMemberModalStore();
-
   const { fetchMember } = useMemberStore();
 
   useEffect(() => {
@@ -48,9 +40,6 @@ export default function ClientLayoutShell({ children }) {
     })();
   }, [user?.user_id, siteInfo?.id, fetchMember, openPending]);
 
-  const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
-
   // Ensure site info is available on the client after hydration
   useEffect(() => {
     if (!siteInfo) {
@@ -58,8 +47,6 @@ export default function ClientLayoutShell({ children }) {
       if (w.__SITE_INFO__) setSiteInfo(w.__SITE_INFO__);
     }
   }, [siteInfo, setSiteInfo]);
-
-  const headerReady = mounted && !!siteInfo;
 
   useEffect(() => {
     const htmlElement = document.documentElement;
@@ -72,68 +59,18 @@ export default function ClientLayoutShell({ children }) {
     }
   }, [i18n.language]);
 
-  const handleLogout = async () => {
-    await logout();
-    router.push(landingPage);
-  };
-
   if (loading) {
-    return (
-      <Loader size={24} thickness={3} text="Loading"/>
-    );
+    return <Loader size={24} thickness={3} text="Loading"/>;
   }
 
   return (
-    <I18nProvider>
-      <I18nGate>
-        <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50">
-          <style>{`
-          :root {
-            --cream-50: #FEFCF8;
-            --cream-100: #FDF8F0;
-            --sage-50: #F7F8F6;
-            --sage-100: #E8EBE6;
-            --sage-200: #D1D8CC;
-            --sage-300: #A8B5A0;
-            --sage-400: #8B9A7B;
-            --sage-500: #6B7A5E;
-            --sage-600: #566249;
-            --sage-700: #454F3B;
-            --sage-800: #373F2F;
-            --sage-900: #2C3E36;
-            --charcoal: #2C3E36;
-          }
-          .bg-cream-50 { background-color: var(--cream-50); }
-          .bg-cream-100 { background-color: var(--cream-100); }
-          .bg-sage-50 { background-color: var(--sage-50); }
-          .bg-sage-100 { background-color: var(--sage-100); }
-          .bg-sage-600 { background-color: var(--sage-600); }
-          .bg-sage-700 { background-color: var(--sage-700); }
-          .text-sage-600 { color: var(--sage-600); }
-          .text-sage-700 { color: var(--sage-700); }
-          .text-charcoal { color: var(--charcoal); }
-          .border-sage-200 { border-color: var(--sage-200); }
-          .border-sage-600 { border-color: var(--sage-600); }
-          .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
-          .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
-        `}</style>
-          {headerReady ? (
-            <Header
-              user={user}
-              member={member}
-              onLogout={handleLogout}
-              siteInfo={siteInfo}
-            />
-          ) : null}
-          {children}
-          <Modal isOpen={isLoginOpen} onClose={closeLogin}>
-            <LoginPage/>
-          </Modal>
-          <Modal isOpen={isPendingOpen} onClose={closePending}>
-            <PendingMemberContent/>
-          </Modal>
-        </div>
-      </I18nGate>
-    </I18nProvider>
+    <>
+      <Modal isOpen={isLoginOpen} onClose={closeLogin}>
+        <LoginPage/>
+      </Modal>
+      <Modal isOpen={isPendingOpen} onClose={closePending}>
+        <PendingMemberContent/>
+      </Modal>
+    </>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,9 @@
+'use client';
+
+export default function Footer() {
+  return (
+    <footer className="w-full py-4 text-center text-sm text-sage-600">
+      &copy; {new Date().getFullYear()} Aglamaz
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,10 +5,11 @@ import Navigation from "@/components/Navigation";
 import { useTranslation } from 'react-i18next';
 import { LogOut, Users, MessageCircle } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { IUser } from "@/entities/User";
-import { IMember } from "@/entities/Member";
-import { ISite } from "@/entities/Site";
 import { useLoginModalStore } from '@/store/LoginModalStore';
+import { useUserStore } from '@/store/UserStore';
+import { useMemberStore } from '@/store/MemberStore';
+import { useSiteStore } from '@/store/SiteStore';
+import { landingPage } from '@/app/settings';
 
 const LANGS = [
   { code: 'he', label: 'עברית', flag: '🇮🇱' },
@@ -16,7 +17,7 @@ const LANGS = [
   { code: 'tr', label: 'Türkçe', flag: '🇹🇷' },
 ];
 
-function getUserInitials(member?: IMember) {
+function getUserInitials(member?) {
   if (!member?.displayName) return 'U';
   return member.displayName
     .split(' ')
@@ -26,14 +27,7 @@ function getUserInitials(member?: IMember) {
     .slice(0, 2);
 }
 
-interface HeaderProps {
-  user?: IUser;
-  member?: IMember;
-  onLogout?: () => void;
-  siteInfo: ISite;
-}
-
-export default function Header({ user, member, onLogout, siteInfo }: HeaderProps) {
+export default function Header() {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [isLangMenuOpen, setIsLangMenuOpen] = useState(false);
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
@@ -41,6 +35,14 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
   const userMenuRef = useRef(null);
   const router = useRouter();
   const openLogin = useLoginModalStore((s) => s.open);
+  const { user, logout } = useUserStore();
+  const member = useMemberStore((state) => state.member);
+  const siteInfo = useSiteStore((state) => state.siteInfo);
+
+  const handleLogout = async () => {
+    await logout();
+    router.push(landingPage);
+  };
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -69,12 +71,12 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
     <header className="w-full flex items-center justify-between px-4 py-2 bg-white shadow-sm sticky top-0 z-50">
       {/* Left: Site title */}
       <div className="text-xl font-semibold text-sage-700">
-        {siteInfo.name}
+        {siteInfo?.name}
       </div>
       {/* Center: Navigation */}
       <div className="flex flex-row items-center">
-        {user && member && onLogout && member.role !== 'pending' && (
-          <Navigation user={user} onLogout={onLogout} setMobileMenuOpen={setMobileMenuOpen}/>
+        {user && member && member.role !== 'pending' && (
+          <Navigation user={user} onLogout={handleLogout} setMobileMenuOpen={setMobileMenuOpen}/>
         )}
       </div>
       {/* Right: Flags + Avatar */}
@@ -106,7 +108,7 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
           )}
         </div>
         {/* Avatar + User Menu */}
-        {user && member && onLogout ? (
+        {user && member ? (
           <div className="hidden md:block relative" ref={userMenuRef}>
             <button
               onClick={() => setIsUserMenuOpen((v) => !v)}
@@ -157,7 +159,7 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
                   <button
                     onClick={() => {
                       setIsUserMenuOpen(false);
-                      onLogout?.();
+                      handleLogout();
                     }}
                     className="flex items-center w-full px-4 py-2 text-sm text-sage-700 hover:bg-sage-50 transition-colors duration-200"
                   >

--- a/src/components/PublicLayoutShell.tsx
+++ b/src/components/PublicLayoutShell.tsx
@@ -55,7 +55,7 @@ export default function PublicLayoutShell({ siteInfo, children }: PublicLayoutSh
             .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
             .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
           `}</style>
-      <Header siteInfo={siteInfo!} />
+      <Header />
       {children}
       <Modal isOpen={isOpen} onClose={close}>
         <LoginPage />


### PR DESCRIPTION
## Summary
- integrate `Header` and `Footer` into root layout and remove ClientLayoutShell wrapper
- move auth and modal side effects into standalone `ClientLayoutShell`
- simplify sub-app layouts and update public layout/header usage

## Testing
- `npx tsc`
- `npx next build` *(fails: Service account object must contain a string "project_id" property)*

------
https://chatgpt.com/codex/tasks/task_e_68ab58674e9083279898447d1c576d1d