### PR TITLE
refactor: move inline styles to css files

### DIFF
--- a/src/app/anniversaries/page.module.css
+++ b/src/app/anniversaries/page.module.css
@@ -1,0 +1,4 @@
+.cropImage {
+  width: 100%;
+  transform: translateY(calc(-1 * var(--offset-y)));
+}

--- a/src/app/anniversaries/page.tsx
+++ b/src/app/anniversaries/page.tsx
@@ -10,6 +10,7 @@ import { getStorage, ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { useUserStore } from '@/store/UserStore';
 import { useMemberStore } from '@/store/MemberStore';
 import { apiFetch } from '@/utils/apiFetch';
+import styles from './page.module.css';
 
 interface AnniversaryEvent {
   id: string;
@@ -51,6 +52,12 @@ export default function AnniversariesPage() {
   const [maxOffsetY, setMaxOffsetY] = useState(0);
   const imgRef = useRef<HTMLImageElement | null>(null);
   const cropRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (imgRef.current) {
+      imgRef.current.style.setProperty('--offset-y', `${offsetY}px`);
+    }
+  }, [offsetY]);
 
   const fetchEvents = async () => {
     setLoading(true);
@@ -374,7 +381,7 @@ export default function AnniversariesPage() {
                     ref={imgRef}
                     src={imageSrc}
                     onLoad={onImageLoad}
-                    style={{ width: '100%', transform: `translateY(-${offsetY}px)` }}
+                    className={styles.cropImage}
                     alt="crop source"
                   />
                 </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,3 +32,34 @@
 .language-menu-item.font-bold {
   font-weight: bold;
 }
+
+/* Theme variables and utility classes */
+:root {
+  --cream-50: #FEFCF8;
+  --cream-100: #FDF8F0;
+  --sage-50: #F7F8F6;
+  --sage-100: #E8EBE6;
+  --sage-200: #D1D8CC;
+  --sage-300: #A8B5A0;
+  --sage-400: #8B9A7B;
+  --sage-500: #6B7A5E;
+  --sage-600: #566249;
+  --sage-700: #454F3B;
+  --sage-800: #373F2F;
+  --sage-900: #2C3E36;
+  --charcoal: #2C3E36;
+}
+
+.bg-cream-50 { background-color: var(--cream-50); }
+.bg-cream-100 { background-color: var(--cream-100); }
+.bg-sage-50 { background-color: var(--sage-50); }
+.bg-sage-100 { background-color: var(--sage-100); }
+.bg-sage-600 { background-color: var(--sage-600); }
+.bg-sage-700 { background-color: var(--sage-700); }
+.text-sage-600 { color: var(--sage-600); }
+.text-sage-700 { color: var(--sage-700); }
+.text-charcoal { color: var(--charcoal); }
+.border-sage-200 { border-color: var(--sage-200); }
+.border-sage-600 { border-color: var(--sage-600); }
+.hover\:bg-sage-700:hover { background-color: var(--sage-700); }
+.hover\:border-sage-300:hover { border-color: var(--sage-300); }

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -88,36 +88,6 @@ export default function ClientLayoutShell({ children }) {
     <I18nProvider>
       <I18nGate>
         <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50">
-          <style>{`
-          :root {
-            --cream-50: #FEFCF8;
-            --cream-100: #FDF8F0;
-            --sage-50: #F7F8F6;
-            --sage-100: #E8EBE6;
-            --sage-200: #D1D8CC;
-            --sage-300: #A8B5A0;
-            --sage-400: #8B9A7B;
-            --sage-500: #6B7A5E;
-            --sage-600: #566249;
-            --sage-700: #454F3B;
-            --sage-800: #373F2F;
-            --sage-900: #2C3E36;
-            --charcoal: #2C3E36;
-          }
-          .bg-cream-50 { background-color: var(--cream-50); }
-          .bg-cream-100 { background-color: var(--cream-100); }
-          .bg-sage-50 { background-color: var(--sage-50); }
-          .bg-sage-100 { background-color: var(--sage-100); }
-          .bg-sage-600 { background-color: var(--sage-600); }
-          .bg-sage-700 { background-color: var(--sage-700); }
-          .text-sage-600 { color: var(--sage-600); }
-          .text-sage-700 { color: var(--sage-700); }
-          .text-charcoal { color: var(--charcoal); }
-          .border-sage-200 { border-color: var(--sage-200); }
-          .border-sage-600 { border-color: var(--sage-600); }
-          .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
-          .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
-        `}</style>
           {headerReady ? (
             <Header
               user={user}

--- a/src/components/PublicLayoutShell.tsx
+++ b/src/components/PublicLayoutShell.tsx
@@ -25,36 +25,6 @@ export default function PublicLayoutShell({ siteInfo, children }: PublicLayoutSh
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-cream-50 to-sage-50">
-      <style>{`
-            :root {
-              --cream-50: #FEFCF8;
-              --cream-100: #FDF8F0;
-              --sage-50: #F7F8F6;
-              --sage-100: #E8EBE6;
-              --sage-200: #D1D8CC;
-              --sage-300: #A8B5A0;
-              --sage-400: #8B9A7B;
-              --sage-500: #6B7A5E;
-              --sage-600: #566249;
-              --sage-700: #454F3B;
-              --sage-800: #373F2F;
-              --sage-900: #2C3E36;
-              --charcoal: #2C3E36;
-            }
-            .bg-cream-50 { background-color: var(--cream-50); }
-            .bg-cream-100 { background-color: var(--cream-100); }
-            .bg-sage-50 { background-color: var(--sage-50); }
-            .bg-sage-100 { background-color: var(--sage-100); }
-            .bg-sage-600 { background-color: var(--sage-600); }
-            .bg-sage-700 { background-color: var(--sage-700); }
-            .text-sage-600 { color: var(--sage-600); }
-            .text-sage-700 { color: var(--sage-700); }
-            .text-charcoal { color: var(--charcoal); }
-            .border-sage-200 { border-color: var(--sage-200); }
-            .border-sage-600 { border-color: var(--sage-600); }
-            .hover\\:bg-sage-700:hover { background-color: var(--sage-700); }
-            .hover\\:border-sage-300:hover { border-color: var(--sage-300); }
-          `}</style>
       <Header siteInfo={siteInfo!} />
       {children}
       <Modal isOpen={isOpen} onClose={close}>

--- a/src/components/ui/Loader.module.css
+++ b/src/components/ui/Loader.module.css
@@ -1,0 +1,5 @@
+.spinner {
+  width: var(--loader-size);
+  height: var(--loader-size);
+  border-width: var(--loader-thickness);
+}

--- a/src/components/ui/Loader.tsx
+++ b/src/components/ui/Loader.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React from "react";
+import React, { useEffect, useRef } from "react";
+import styles from './Loader.module.css';
 
 type LoaderProps = {
   text?: string;            // Optional label next to the spinner
@@ -21,8 +22,7 @@ export const Loader: React.FC<LoaderProps> = ({
                                          className = "",
                                        }) => {
   const base = "grid place-items-center";
-  const surface =
-    blur ? "bg-white/70 backdrop-blur-sm" : "bg-transparent";
+  const surface = blur ? "bg-white/70 backdrop-blur-sm" : "bg-transparent";
 
   // Choose wrapper mode
   const wrapper = fullscreen
@@ -31,11 +31,14 @@ export const Loader: React.FC<LoaderProps> = ({
       ? `absolute inset-0 ${surface} ${base}`
       : base;
 
-  const spinnerStyle: React.CSSProperties = {
-    width: size,
-    height: size,
-    borderWidth: thickness,
-  };
+  const spinnerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (spinnerRef.current) {
+      spinnerRef.current.style.setProperty('--loader-size', `${size}px`);
+      spinnerRef.current.style.setProperty('--loader-thickness', `${thickness}px`);
+    }
+  }, [size, thickness]);
 
   return (
     <div
@@ -46,8 +49,8 @@ export const Loader: React.FC<LoaderProps> = ({
     >
       <div className="flex items-center gap-3">
         <div
-          className="animate-spin rounded-full border-gray-300 border-t-gray-700"
-          style={spinnerStyle}
+          ref={spinnerRef}
+          className={`animate-spin rounded-full border-gray-300 border-t-gray-700 ${styles.spinner}`}
         />
         {text ? (
           <span className="text-sm text-slate-700">{text}</span>

--- a/src/services/GmailService.ts
+++ b/src/services/GmailService.ts
@@ -89,6 +89,8 @@ export class GmailService {
           .button { display: inline-block; background: #007bff; color: white; padding: 12px 24px; text-decoration: none; border-radius: 6px; margin: 20px 0; }
           .footer { text-align: center; padding: 20px; color: #666; font-size: 14px; }
           .warning { background: #fff3cd; border: 1px solid #ffeaa7; padding: 15px; border-radius: 6px; margin: 20px 0; }
+          .text-center { text-align: center; }
+          .break-url { word-break: break-all; color: #007bff; }
         </style>
       </head>
       <body>
@@ -103,7 +105,7 @@ export class GmailService {
             
             <p>תודה שנרשמת למערכת FamilyCircle. כדי להשלים את ההרשמה, אנא לחץ על הכפתור למטה:</p>
             
-            <div style="text-align: center;">
+            <div class="text-center">
               <a href="${verificationUrl}" class="button">אמת את האימייל שלך</a>
             </div>
             
@@ -112,7 +114,7 @@ export class GmailService {
             </div>
             
             <p>אם הכפתור לא עובד, העתק והדבק את הקישור הבא בדפדפן:</p>
-            <p style="word-break: break-all; color: #007bff;">${verificationUrl}</p>
+            <p class="break-url">${verificationUrl}</p>
             
             <p>אם לא ביקשת להירשם למערכת זו, אנא התעלם מהודעה זו.</p>
           </div>


### PR DESCRIPTION
## Summary
- extract theme variables and utility classes into `globals.css`
- remove inline `<style>` tags from layout shells
- move component-specific styling into CSS modules and classes

## Testing
- `npx tsc --noEmit`
- `npx next build` *(fails: process did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5d18df808327b9a37e303730f747