### PR TITLE
Clarify member status and pending handling

### DIFF
--- a/src/app/api/user/member-info/route.ts
+++ b/src/app/api/user/member-info/route.ts
@@ -1,19 +1,42 @@
-import {withMemberGuard} from "@/lib/withMemberGuard";
+import { withUserGuard } from "@/lib/withUserGuard";
 import { GuardContext, RouteHandler } from "@/app/api/types";
+import { FamilyRepository } from '@/repositories/FamilyRepository';
 
 export const dynamic = 'force-dynamic';
 
 const handler: RouteHandler = async (request: Request, context: GuardContext) => {
   try {
-    const { member } = context;
-
-    if (!member) {
-      return Response.json({ error: 'Member not found' }, { status: 404 });
+    const url = new URL(request.url);
+    const siteId = url.searchParams.get('siteId');
+    if (!siteId) {
+      return Response.json({ error: 'Missing required field: siteId' }, { status: 400 });
     }
-    return Response.json({ success: true, member });
+
+    const userId = context.user?.sub;
+    if (!userId) {
+      return Response.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const familyRepository = new FamilyRepository();
+    const member = await familyRepository.getMemberByUserId(userId, siteId);
+
+    if (member) {
+      if (['member', 'admin'].includes(member.role)) {
+        return Response.json({ success: true, status: 'member', member });
+      }
+      return Response.json({ success: true, status: 'pending', member });
+    }
+
+    const signupRequest = await familyRepository.getSignupRequestByUserId(userId, siteId);
+    if (signupRequest) {
+      return Response.json({ success: true, status: 'pending', signupRequest });
+    }
+
+    return Response.json({ success: true, status: 'not_applied' });
   } catch (error) {
     return Response.json({ error: 'Failed to fetch member info' }, { status: 500 });
   }
 };
 
-export const GET = withMemberGuard(handler);
+export const GET = withUserGuard(handler);
+

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -44,10 +44,14 @@ export default function ClientLayoutShell({ children }) {
     if (!user?.user_id || !siteInfo?.id) return;
 
     (async () => {
-      const ok = await fetchMember(user.user_id, siteInfo.id);
-      if (!ok && !useMemberStore.getState().error) openPending();
+      const status = await fetchMember(user.user_id, siteInfo.id);
+      if (status === 'pending') {
+        openPending();
+      } else if (status === 'not_applied') {
+        openLogin();
+      }
     })();
-  }, [user?.user_id, siteInfo?.id, fetchMember, openPending]);
+  }, [user?.user_id, siteInfo?.id, fetchMember, openPending, openLogin]);
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);

--- a/src/components/LoginPage.tsx
+++ b/src/components/LoginPage.tsx
@@ -80,7 +80,7 @@ export default function LoginPage() {
           user_id: result.user.uid,
         });
 
-        router.push('/');
+        router.replace('/app');
         closeLogin();
       }
     } catch (error: any) {

--- a/src/repositories/FamilyRepository.ts
+++ b/src/repositories/FamilyRepository.ts
@@ -437,6 +437,28 @@ export class FamilyRepository {
     }
   }
 
+  async getSignupRequestByUserId(userId: string, siteId: string): Promise<SignupRequest | null> {
+    try {
+      const db = this.getDb();
+      const querySnapshot = await db.collection(this.signupRequestsCollection)
+        .where('userId', '==', userId)
+        .where('siteId', '==', siteId)
+        .orderBy('createdAt', 'desc')
+        .limit(1)
+        .get();
+
+      if (querySnapshot.empty) {
+        return null;
+      }
+
+      const doc = querySnapshot.docs[0];
+      return { id: doc.id, ...doc.data() } as SignupRequest;
+    } catch (error) {
+      console.error('Error getting signup request by user ID:', error);
+      throw new Error('Failed to get signup request by user ID');
+    }
+  }
+
   async getSignupRequestByEmail(email: string, siteId: string): Promise<SignupRequest | null> {
     try {
       const db = this.getDb();


### PR DESCRIPTION
## Summary
- Return explicit membership status from member-info API and check signup requests
- Fetch member status on client to show signup or pending modals accordingly
- Redirect email login to /app

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68ab64ec6ea0832792758fbcd5dbed52