### PR TITLE
fix: raise modal z-index above navigation

### DIFF
--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -12,7 +12,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, isClosable = t
 
   return (
     <div
-      className="fixed inset-0 flex items-center justify-center bg-black/40"
+      className="fixed inset-0 z-[1000] flex items-center justify-center bg-black/40"
       role="dialog"
       aria-modal="true"
     >


### PR DESCRIPTION
## Summary
- ensure `Modal` overlay sits above `Header`/`Navigation` by adding high z-index

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68ab6522add08327822000bcd2722f71