### PR TITLE
Include /api/auth/me in refresh handling

### DIFF
--- a/src/utils/apiFetch.ts
+++ b/src/utils/apiFetch.ts
@@ -11,7 +11,8 @@ function refreshOnce() {
   }));
 }
 
-const AUTH_RE = /^\/api\/auth\/(refresh|login|logout|me)(?:$|\?)/;
+// Endpoints that should bypass refresh logic
+const AUTH_RE = /^\/api\/auth\/(refresh|login|logout)(?:$|\?)/;
 
 export async function apiFetch<T = unknown>(
   input: RequestInfo | URL,
@@ -20,7 +21,7 @@ export async function apiFetch<T = unknown>(
   const url = typeof input === 'string' ? input : (input as URL).toString();
   const req = () => fetch(input, { ...init, credentials: 'include' });
 
-  // 1) Never run refresh logic on auth endpoints themselves
+  // 1) Never run refresh logic on login/logout/refresh endpoints themselves
   if (AUTH_RE.test(url)) {
     const r = await req();
     if (!r.ok) throw new Error(`HTTP ${r.status} ${r.statusText}`);


### PR DESCRIPTION
## Summary
- Allow `/api/auth/me` requests to trigger refresh logic for expired sessions
- Clarify comment for auth bypassed endpoints

## Testing
- `npx tsx test_apiFetch.ts` *(manual verification of refresh flow)*
- `npx tsc --pretty false`

------
https://chatgpt.com/codex/tasks/task_e_68abe3ca332083278a7680382e4ded90