### PR TITLE
feat: add membership application flow for non-members

### DIFF
--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -16,6 +16,8 @@ import LoginPage from '@/components/LoginPage';
 import { useLoginModalStore } from '@/store/LoginModalStore';
 import PendingMemberContent from '@/components/PendingMemberContent';
 import { usePendingMemberModalStore } from '@/store/PendingMemberModalStore';
+import NotMemberContent from '@/components/NotMemberContent';
+import { useNotMemberModalStore } from '@/store/NotMemberModalStore';
 
 export default function ClientLayoutShell({ children }) {
   const { user, loading, logout, checkAuth } = useUserStore();
@@ -26,6 +28,7 @@ export default function ClientLayoutShell({ children }) {
   const { t, i18n } = useTranslation();
   const { isOpen: isLoginOpen, close: closeLogin, open: openLogin } = useLoginModalStore();
   const { isOpen: isPendingOpen, close: closePending, open: openPending } = usePendingMemberModalStore();
+  const { isOpen: isApplyOpen, close: closeApply, open: openApply } = useNotMemberModalStore();
 
   const { fetchMember } = useMemberStore();
 
@@ -46,13 +49,13 @@ export default function ClientLayoutShell({ children }) {
     (async () => {
       const status = await fetchMember(user.user_id, siteInfo.id);
       console.log("Status is ", status);
-      if (status === MembershipStatus.Member) {
+      if (status === MembershipStatus.Pending) {
         openPending();
       } else if (status === MembershipStatus.NotApplied) {
-        openLogin();
+        openApply();
       }
     })();
-  }, [user?.user_id, siteInfo?.id, fetchMember, openPending, openLogin]);
+  }, [user?.user_id, siteInfo?.id, fetchMember, openPending, openApply]);
 
   const [mounted, setMounted] = useState(false);
   useEffect(() => setMounted(true), []);
@@ -108,6 +111,9 @@ export default function ClientLayoutShell({ children }) {
           </Modal>
           <Modal isOpen={isPendingOpen} onClose={closePending} isClosable={false}>
             <PendingMemberContent/>
+          </Modal>
+          <Modal isOpen={isApplyOpen} onClose={closeApply}>
+            <NotMemberContent/>
           </Modal>
         </div>
       </I18nGate>

--- a/src/components/NotMemberContent.tsx
+++ b/src/components/NotMemberContent.tsx
@@ -1,0 +1,16 @@
+'use client';
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import SignupForm from '@/components/SignupForm';
+import { useNotMemberModalStore } from '@/store/NotMemberModalStore';
+
+export default function NotMemberContent() {
+  const { i18n } = useTranslation();
+  const { close } = useNotMemberModalStore();
+
+  return (
+    <div className="flex justify-center" dir={i18n.dir()} lang={i18n.language}>
+      <SignupForm onSuccess={close} onCancel={close} />
+    </div>
+  );
+}

--- a/src/store/NotMemberModalStore.ts
+++ b/src/store/NotMemberModalStore.ts
@@ -1,0 +1,14 @@
+'use client';
+import { create } from 'zustand';
+
+interface NotMemberModalStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useNotMemberModalStore = create<NotMemberModalStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- present membership signup modal when authenticated users are not members
- fix membership status check to show pending approval modal only when status is pending

## Testing
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68abea052c7c832783c74c9332c2289e