### PR TITLE
fix: improve email verification and encoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "zustand": "^5.0.6"
       },
       "devDependencies": {
+        "@types/node": "^24.3.0",
         "@types/react": "19.1.8",
         "autoprefixer": "^10.4.0",
         "postcss": "^8.4.0",
@@ -2226,12 +2227,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.0.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.15.tgz",
-      "integrity": "sha512-oaeTSbCef7U/z7rDeJA138xpG3NuKc64/rZ2qmUFkFJmnMsAPaluIifqyWd8hSSMxyP9oie3dLAqYPblag9KgA==",
+      "version": "24.3.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
+      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/qs": {
@@ -6393,9 +6394,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
     "node_modules/undici/node_modules/@fastify/busboy": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "pug": "^3.0.2"
   },
   "devDependencies": {
+    "@types/node": "^24.3.0",
     "@types/react": "19.1.8",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",

--- a/src/repositories/FamilyRepository.ts
+++ b/src/repositories/FamilyRepository.ts
@@ -320,6 +320,9 @@ export class FamilyRepository {
       };
     } catch (error) {
       console.error('Error verifying signup request:', error);
+      if (error instanceof Error) {
+        throw error;
+      }
       throw new Error('Failed to verify signup request');
     }
   }

--- a/src/services/GmailService.ts
+++ b/src/services/GmailService.ts
@@ -39,11 +39,14 @@ export class GmailService {
         throw new Error('GMAIL_FROM_EMAIL not configured');
       }
 
+      // Encode subject to support non-ASCII characters
+      const encodedSubject = `=?UTF-8?B?${Buffer.from(subject).toString('base64')}?=`;
+
       // Create email message
       const message = [
         `From: ${from}`,
         `To: ${to}`,
-        `Subject: ${subject}`,
+        `Subject: ${encodedSubject}`,
         'MIME-Version: 1.0',
         'Content-Type: text/html; charset=utf-8',
         '',


### PR DESCRIPTION
## Summary
- encode Gmail subject headers in UTF-8 to display non-ASCII text correctly
- rethrow original signup verification errors instead of generic message
- include `@types/node` for TypeScript support

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68ac81cfcfd08327a4a5a1376b85ffe6