### PR TITLE
feat: add blog repository

### DIFF
--- a/src/entities/BlogPost.ts
+++ b/src/entities/BlogPost.ts
@@ -1,0 +1,9 @@
+export interface IBlogPost {
+  id: string;
+  authorId: string;
+  title: string;
+  content: string;
+  isPublic: boolean;
+  createdAt: any;
+  updatedAt: any;
+}

--- a/src/repositories/BlogRepository.ts
+++ b/src/repositories/BlogRepository.ts
@@ -1,0 +1,46 @@
+import { getFirestore, Timestamp } from 'firebase-admin/firestore';
+import { initAdmin } from '../firebase/admin';
+import type { IBlogPost } from '@/entities/BlogPost';
+
+export class BlogRepository {
+  private readonly collection = 'blogPosts';
+
+  private getDb() {
+    initAdmin();
+    return getFirestore();
+  }
+
+  async create(post: Omit<IBlogPost, 'id' | 'createdAt' | 'updatedAt'>): Promise<IBlogPost> {
+    const db = this.getDb();
+    const ref = db.collection(this.collection).doc();
+    const now = Timestamp.now();
+    const data = { ...post, createdAt: now, updatedAt: now };
+    await ref.set(data);
+    return { id: ref.id, ...data };
+  }
+
+  async getById(id: string): Promise<IBlogPost | null> {
+    const db = this.getDb();
+    const doc = await db.collection(this.collection).doc(id).get();
+    if (!doc.exists) return null;
+    return { id: doc.id, ...(doc.data() as Omit<IBlogPost, 'id'>) } as IBlogPost;
+  }
+
+  async update(id: string, updates: Partial<Omit<IBlogPost, 'id' | 'createdAt' | 'updatedAt'>>): Promise<void> {
+    const db = this.getDb();
+    await db.collection(this.collection).doc(id).update({ ...updates, updatedAt: Timestamp.now() });
+  }
+
+  async delete(id: string): Promise<void> {
+    const db = this.getDb();
+    await db.collection(this.collection).doc(id).delete();
+  }
+
+  async getAll(): Promise<IBlogPost[]> {
+    const db = this.getDb();
+    const snap = await db.collection(this.collection).orderBy('createdAt', 'desc').get();
+    return snap.docs.map(doc => ({ id: doc.id, ...(doc.data() as Omit<IBlogPost, 'id'>) })) as IBlogPost[];
+  }
+}
+
+export const blogRepository = new BlogRepository();


### PR DESCRIPTION
## Summary
- add BlogPost entity definition
- implement Firestore-backed BlogRepository with basic CRUD

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68b078abe6b08327956b6f46e08e6ce1