### PR TITLE
feat(blog): add public post page with likes and shares

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "zustand": "^5.0.6"
       },
       "devDependencies": {
+        "@types/dompurify": "^3.0.5",
         "@types/react": "19.1.8",
         "autoprefixer": "^10.4.0",
         "postcss": "^8.4.0",
@@ -2176,6 +2177,16 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
@@ -2322,8 +2333,8 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@types/dompurify": "^3.0.5",
     "@types/react": "19.1.8",
     "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",

--- a/src/app/api/blog/[postId]/like/route.ts
+++ b/src/app/api/blog/[postId]/like/route.ts
@@ -1,0 +1,18 @@
+import { initAdmin } from '@/firebase/admin';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+export const dynamic = 'force-dynamic';
+
+export const POST = async (_request: Request, { params }: { params: { postId: string } }) => {
+  try {
+    initAdmin();
+    const db = getFirestore();
+    const ref = db.collection('blogPosts').doc(params.postId);
+    await ref.update({ likeCount: FieldValue.increment(1) });
+    const snap = await ref.get();
+    return Response.json({ likeCount: snap.data()?.likeCount ?? 0 });
+  } catch (error) {
+    console.error('Failed to increment like:', error);
+    return Response.json({ error: 'Failed to increment like' }, { status: 500 });
+  }
+};

--- a/src/app/api/blog/[postId]/share/route.ts
+++ b/src/app/api/blog/[postId]/share/route.ts
@@ -1,0 +1,18 @@
+import { initAdmin } from '@/firebase/admin';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+export const dynamic = 'force-dynamic';
+
+export const POST = async (_request: Request, { params }: { params: { postId: string } }) => {
+  try {
+    initAdmin();
+    const db = getFirestore();
+    const ref = db.collection('blogPosts').doc(params.postId);
+    await ref.update({ shareCount: FieldValue.increment(1) });
+    const snap = await ref.get();
+    return Response.json({ shareCount: snap.data()?.shareCount ?? 0 });
+  } catch (error) {
+    console.error('Failed to increment share:', error);
+    return Response.json({ error: 'Failed to increment share' }, { status: 500 });
+  }
+};

--- a/src/app/public/blog/[postId]/page.tsx
+++ b/src/app/public/blog/[postId]/page.tsx
@@ -1,0 +1,12 @@
+import { BlogRepository } from '@/repositories/BlogRepository';
+import { notFound } from 'next/navigation';
+import PublicPost from '@/components/blog/PublicPost';
+
+export default async function PublicBlogPostPage({ params }: { params: { postId: string } }) {
+  const repo = new BlogRepository();
+  const post = await repo.getById(params.postId);
+  if (!post || !post.isPublic) {
+    notFound();
+  }
+  return <PublicPost post={post} />;
+}

--- a/src/app/public/layout.tsx
+++ b/src/app/public/layout.tsx
@@ -1,0 +1,14 @@
+import PublicLayoutShell from '@/components/PublicLayoutShell';
+import { fetchSiteInfo } from '@/firebase/admin';
+
+export default async function PublicLayout({ children }: { children: React.ReactNode }) {
+  let siteInfo = null;
+  try {
+    siteInfo = await fetchSiteInfo();
+  } catch (error) {
+    console.error('Failed to fetch site info:', error);
+    throw error;
+  }
+
+  return <PublicLayoutShell siteInfo={siteInfo}>{children}</PublicLayoutShell>;
+}

--- a/src/components/blog/PublicPost.tsx
+++ b/src/components/blog/PublicPost.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import type { IBlogPost } from '@/entities/BlogPost';
+import { Button } from '@/components/ui/button';
+
+interface Props {
+  post: IBlogPost;
+}
+
+export default function PublicPost({ post }: Props) {
+  const { t } = useTranslation();
+  const [likes, setLikes] = useState(post.likeCount ?? 0);
+  const [shares, setShares] = useState(post.shareCount ?? 0);
+  const [liking, setLiking] = useState(false);
+
+  const handleLike = async () => {
+    setLiking(true);
+    try {
+      const res = await fetch(`/api/blog/${post.id}/like`, { method: 'POST' });
+      const data = await res.json();
+      setLikes(data.likeCount ?? likes + 1);
+      return true;
+    } catch (error) {
+      console.error('Failed to like post:', error);
+      return false;
+    } finally {
+      setLiking(false);
+    }
+  };
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    try {
+      if (navigator.share) {
+        await navigator.share({ url });
+      } else {
+        await navigator.clipboard.writeText(url);
+      }
+      await fetch(`/api/blog/${post.id}/share`, { method: 'POST' });
+      setShares((s) => s + 1);
+      return true;
+    } catch (error) {
+      console.error('Failed to share post:', error);
+      return false;
+    }
+  };
+
+  return (
+    <article className="prose max-w-none mx-auto py-8">
+      <h1 className="mb-4">{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.content }} />
+      <div className="flex items-center space-x-4 mt-6">
+        <Button onClick={handleLike} disabled={liking}>
+          {t('like')} ({likes})
+        </Button>
+        <Button onClick={handleShare}>
+          {t('share')} ({shares})
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/src/entities/BlogPost.ts
+++ b/src/entities/BlogPost.ts
@@ -4,6 +4,8 @@ export interface IBlogPost {
   title: string;
   content: string;
   isPublic: boolean;
+  likeCount?: number;
+  shareCount?: number;
   createdAt: any;
   updatedAt: any;
 }

--- a/src/repositories/BlogRepository.ts
+++ b/src/repositories/BlogRepository.ts
@@ -14,7 +14,13 @@ export class BlogRepository {
     const db = this.getDb();
     const ref = db.collection(this.collection).doc();
     const now = Timestamp.now();
-    const data = { ...post, createdAt: now, updatedAt: now };
+    const data = {
+      likeCount: 0,
+      shareCount: 0,
+      ...post,
+      createdAt: now,
+      updatedAt: now,
+    };
     await ref.set(data);
     return { id: ref.id, ...data };
   }


### PR DESCRIPTION
## Summary
- display public blog posts under `/public/blog/[postId]`
- support liking posts via unauthenticated API route
- track social shares and likes counts

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68b354cb9a388327b61271ae1edf0b70