### PR TITLE
fix: wrap long lines in blog posts

### DIFF
--- a/src/app/(public)/blog/author/[id]/page.tsx
+++ b/src/app/(public)/blog/author/[id]/page.tsx
@@ -5,6 +5,7 @@ import { FamilyRepository } from '@/repositories/FamilyRepository';
 import { headers, cookies } from 'next/headers';
 import TranslationTrigger from '@/components/blog/TranslationTrigger';
 import I18nText from '@/components/I18nText';
+import blogStyles from '@/components/blog/BlogContent.module.css';
 
 export const dynamic = 'force-dynamic';
 
@@ -72,7 +73,7 @@ export default async function AuthorBlogPage({ params, searchParams }: { params:
           </CardHeader>
           <CardContent>
             <div
-              className="prose max-w-none"
+              className={`prose max-w-none ${blogStyles.content}`}
               dangerouslySetInnerHTML={{ __html: post.content || '' }}
             />
           </CardContent>

--- a/src/app/(public)/blog/family/page.tsx
+++ b/src/app/(public)/blog/family/page.tsx
@@ -9,6 +9,7 @@ import AddPostFab from '@/components/blog/AddPostFab';
 import I18nText from '@/components/I18nText';
 import TranslationTrigger from '@/components/blog/TranslationTrigger';
 import { headers } from 'next/headers';
+import blogStyles from '@/components/blog/BlogContent.module.css';
 
 export const dynamic = 'force-dynamic';
 
@@ -88,7 +89,7 @@ export default async function FamilyBlogPage({ searchParams }: { searchParams?: 
           </CardHeader>
           <CardContent>
             <div className={`rounded-lg p-3 ${tint}`}>
-              <div className={`text-sm text-gray-700 ${styles.clamp3}`} dangerouslySetInnerHTML={{ __html: post.content || '' }} />
+              <div className={`text-sm text-gray-700 ${styles.clamp3} ${blogStyles.content}`} dangerouslySetInnerHTML={{ __html: post.content || '' }} />
             </div>
             <div className="mt-2">
               <a className="text-blue-600 hover:underline text-sm" href={`/blog/author/${handle}?lang=${lang}`}>

--- a/src/components/blog/BlogContent.module.css
+++ b/src/components/blog/BlogContent.module.css
@@ -1,0 +1,4 @@
+.content * {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}

--- a/src/components/blog/PublicPost.tsx
+++ b/src/components/blog/PublicPost.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { IBlogPost } from '@/entities/BlogPost';
 import { Button } from '@/components/ui/button';
+import styles from './BlogContent.module.css';
 
 interface Props {
   post: IBlogPost;
@@ -48,7 +49,7 @@ export default function PublicPost({ post }: Props) {
   };
 
   return (
-    <article className="prose max-w-none mx-auto py-8">
+    <article className={`prose max-w-none mx-auto py-8 ${styles.content}`}>
       <h1 className="mb-4">{post.title}</h1>
       <div dangerouslySetInnerHTML={{ __html: post.content }} />
       <div className="flex items-center space-x-4 mt-6">


### PR DESCRIPTION
## Summary
- ensure long strings in blog posts wrap within page width
- apply shared wrapping styles to author and family blog listings

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_68bde4ae1ad88327a9077386b4e6d765