### PR TITLE
fix: prevent footer overlap on landing page

### DIFF
--- a/src/components/home/LandingPage.tsx
+++ b/src/components/home/LandingPage.tsx
@@ -8,9 +8,9 @@ import { useTranslation } from 'react-i18next';
 export default function LandingPage() {
   const { t } = useTranslation();
   return (
-    <div className="min-h-screen">
+    <div>
       <WelcomeHero user={null} title={t('welcomeToFamilyCircle')} subtitle={t('stayConnected')} />
-      <div className="text-center mt-8">
+      <div className="text-center mt-8 mb-20">
         <Link href="/app" className="bg-sage-600 text-white px-6 py-2 rounded-lg">
           Get started
         </Link>


### PR DESCRIPTION
## Summary
- avoid landing page footer overlapping by removing full-screen height and adding bottom spacing

## Testing
- `npm run --silent tsc`


------
https://chatgpt.com/codex/tasks/task_e_68bdef2d1ff883279905482f329387ea