### PR TITLE
Use gravatar avatar visible on mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@tinymce/tinymce-react": "^6.3.0",
+        "blueimp-md5": "^2.19.0",
         "dompurify": "^3.2.6",
         "dotenv": "^17.2.1",
         "firebase": "^10.7.1",
@@ -2587,6 +2588,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/blueimp-md5": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.19.0.tgz",
+      "integrity": "sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tinymce/tinymce-react": "^6.3.0",
+    "blueimp-md5": "^2.19.0",
     "dompurify": "^3.2.6",
     "dotenv": "^17.2.1",
     "firebase": "^10.7.1",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,6 +9,7 @@ import { IUser } from "@/entities/User";
 import { IMember } from "@/entities/Member";
 import { ISite } from "@/entities/Site";
 import { useLoginModalStore } from '@/store/LoginModalStore';
+import md5 from 'blueimp-md5';
 
 const LANGS = [
   { code: 'he', label: 'עברית', flag: '🇮🇱' },
@@ -16,14 +17,9 @@ const LANGS = [
   { code: 'tr', label: 'Türkçe', flag: '🇹🇷' },
 ];
 
-function getUserInitials(member?: IMember) {
-  if (!member?.displayName) return 'U';
-  return member.displayName
-    .split(' ')
-    .map((n) => n[0])
-    .join('')
-    .toUpperCase()
-    .slice(0, 2);
+function getGravatarUrl(email?: string) {
+  const hash = md5((email || '').trim().toLowerCase());
+  return `https://www.gravatar.com/avatar/${hash}?s=80&d=identicon`;
 }
 
 interface HeaderProps {
@@ -43,6 +39,7 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const openLogin = useLoginModalStore((s) => s.open);
+  const avatarUrl = getGravatarUrl(member?.email);
 
   useEffect(() => {
     function handleClickOutside(event) {
@@ -133,13 +130,13 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
         </div>
         {/* Avatar + User Menu */}
         {user && member && onLogout ? (
-          <div className="hidden md:block relative" ref={userMenuRef}>
+          <div className="relative" ref={userMenuRef}>
             <button
               onClick={() => setIsUserMenuOpen((v) => !v)}
-              className="h-8 w-8 rounded-full bg-sage-600 flex items-center justify-center text-white text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sage-500 transition-colors duration-200"
+              className="h-8 w-8 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-sage-500 transition-colors duration-200"
               aria-label={t('userMenu') as string}
             >
-              {getUserInitials(member)}
+              <img src={avatarUrl} alt="" className="h-full w-full object-cover" />
             </button>
             {isUserMenuOpen && (
               <div


### PR DESCRIPTION
## Summary
- show user avatar on small screens
- replace initials avatar with gravatar image
- add blueimp-md5 for gravatar hashing

## Testing
- `npx tsc`
- `npx next build` *(fails: Service account object must contain a string "private_key" property)*

------
https://chatgpt.com/codex/tasks/task_e_68c2642a0c648327bf160da806e18f1b