### PR TITLE
feat: add user profile editing modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "zustand": "^5.0.6"
       },
       "devDependencies": {
+        "@types/blueimp-md5": "^2.18.2",
         "@types/dompurify": "^3.0.5",
         "@types/react": "19.1.8",
         "autoprefixer": "^10.4.0",
@@ -2149,6 +2150,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/blueimp-md5": {
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@types/blueimp-md5/-/blueimp-md5-2.18.2.tgz",
+      "integrity": "sha512-dJ9yRry9Olt5GAWlgCtE5dK9d/Dfhn/V7hna86eEO2Pn76+E8Y0S0n61iEUEGhWXXgtKtHxtZLVNwL8X+vLHzg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "zustand": "^5.0.6"
   },
   "devDependencies": {
+    "@types/blueimp-md5": "^2.18.2",
     "@types/dompurify": "^3.0.5",
     "@types/react": "19.1.8",
     "autoprefixer": "^10.4.0",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -4,6 +4,7 @@
   "pendingApprovalNotify": "You will be notified when your request is approved.",
   "contactUs": "Contact Us",
   "logout": "Logout",
+  "editProfile": "Edit Profile",
   "user": "User",
   "pendingApprovalRequestSent": "Request sent successfully",
   "pendingApprovalWaitingAdmin": "Waiting for admin approval",

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -4,6 +4,7 @@
   "pendingApprovalNotify": "תקבל הודעה כאשר הבקשה תאושר.",
   "contactUs": "צור קשר",
   "logout": "התנתק",
+  "editProfile": "ערוך פרופיל",
   "user": "משתמש",
   "pendingApprovalRequestSent": "בקשה נשלחה בהצלחה",
   "pendingApprovalWaitingAdmin": "ממתין לאישור מהמנהל",

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -18,6 +18,7 @@
   "pendingApprovalStatus": "Onay Bekliyor",
   "verified": "Doğrulandı",
   "logout": "Çıkış Yap",
+  "editProfile": "Profil Düzenle",
   "user": "Kullanıcı",
   "pendingApprovalRequestSent": "Talep başarıyla gönderildi",
   "pendingApprovalWaitingAdmin": "Yönetici onayı bekleniyor",

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -18,6 +18,8 @@ import PendingMemberContent from '@/components/PendingMemberContent';
 import { usePendingMemberModalStore } from '@/store/PendingMemberModalStore';
 import NotMemberContent from '@/components/NotMemberContent';
 import { useNotMemberModalStore } from '@/store/NotMemberModalStore';
+import EditUserDetails from '@/components/EditUserDetails';
+import { useEditUserModalStore } from '@/store/EditUserModalStore';
 
 export default function ClientLayoutShell({ children }) {
   const { user, loading, logout, checkAuth } = useUserStore();
@@ -29,6 +31,7 @@ export default function ClientLayoutShell({ children }) {
   const { isOpen: isLoginOpen, close: closeLogin, open: openLogin } = useLoginModalStore();
   const { isOpen: isPendingOpen, close: closePending, open: openPending } = usePendingMemberModalStore();
   const { isOpen: isApplyOpen, close: closeApply, open: openApply } = useNotMemberModalStore();
+  const { isOpen: isEditOpen, close: closeEdit } = useEditUserModalStore();
 
   const { fetchMember } = useMemberStore();
 
@@ -115,6 +118,9 @@ export default function ClientLayoutShell({ children }) {
           </Modal>
           <Modal isOpen={isApplyOpen} onClose={closeApply}>
             <NotMemberContent/>
+          </Modal>
+          <Modal isOpen={isEditOpen} onClose={closeEdit}>
+            <EditUserDetails/>
           </Modal>
         </div>
       </I18nGate>

--- a/src/components/EditUserDetails.tsx
+++ b/src/components/EditUserDetails.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { apiFetch } from '@/utils/apiFetch';
+import { useUserStore } from '@/store/UserStore';
+import { IUser } from '@/entities/User';
+import { useEditUserModalStore } from '@/store/EditUserModalStore';
+
+export default function EditUserDetails() {
+  const { user, setUser } = useUserStore();
+  const [name, setName] = useState(user?.name || '');
+  const [email, setEmail] = useState(user?.email || '');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+  const { t, i18n } = useTranslation();
+  const { close } = useEditUserModalStore();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !email.trim()) {
+      setError(t('pleaseFillAllFields'));
+      return;
+    }
+    setIsLoading(true);
+    setError('');
+    try {
+      const updated = await apiFetch<IUser>('/api/user/update', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: name.trim(), email: email.trim() }),
+      });
+      setUser(updated);
+      close();
+    } catch (err) {
+      setError(t('failedToSubmit'));
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="w-full max-w-md" dir={i18n.dir()} lang={i18n.language}>
+      <h2 className="text-xl font-semibold mb-4">{t('editProfile')}</h2>
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg text-red-600 text-sm">{error}</div>
+      )}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm mb-1" htmlFor="name">{t('name')}</label>
+          <input
+            id="name"
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            disabled={isLoading}
+          />
+        </div>
+        <div>
+          <label className="block text-sm mb-1" htmlFor="email">{t('email')}</label>
+          <input
+            id="email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full border border-gray-300 rounded px-3 py-2"
+            disabled={isLoading}
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={close}
+            className="px-4 py-2 rounded bg-gray-200"
+            disabled={isLoading}
+          >
+            {t('cancel')}
+          </button>
+          <button
+            type="submit"
+            className="px-4 py-2 rounded bg-sage-600 text-white disabled:opacity-50"
+            disabled={isLoading}
+          >
+            {isLoading ? t('saving') : t('save')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,12 +3,13 @@
 import React, { useState, useRef, useEffect } from "react";
 import Navigation from "@/components/Navigation";
 import { useTranslation } from 'react-i18next';
-import { LogOut, Users, MessageCircle, Home as HomeIcon, BookOpen } from 'lucide-react';
+import { LogOut, Users, MessageCircle, Home as HomeIcon, BookOpen, User } from 'lucide-react';
 import { useRouter, usePathname, useSearchParams } from 'next/navigation';
 import { IUser } from "@/entities/User";
 import { IMember } from "@/entities/Member";
 import { ISite } from "@/entities/Site";
 import { useLoginModalStore } from '@/store/LoginModalStore';
+import { useEditUserModalStore } from '@/store/EditUserModalStore';
 import md5 from 'blueimp-md5';
 
 const LANGS = [
@@ -39,6 +40,7 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
   const pathname = usePathname();
   const searchParams = useSearchParams();
   const openLogin = useLoginModalStore((s) => s.open);
+  const openEdit = useEditUserModalStore((s) => s.open);
   const avatarUrl = getGravatarUrl(member?.email);
 
   useEffect(() => {
@@ -177,6 +179,16 @@ export default function Header({ user, member, onLogout, siteInfo }: HeaderProps
                       </button>
                     </>
                   )}
+                  <button
+                    onClick={() => {
+                      setIsUserMenuOpen(false);
+                      openEdit();
+                    }}
+                    className="flex items-center w-full px-4 py-2 text-sm text-sage-700 hover:bg-sage-50 transition-colors duration-200"
+                  >
+                    <User size={16} className="mr-3"/>
+                    {t('editProfile')}
+                  </button>
                   <button
                     onClick={() => {
                       setIsUserMenuOpen(false);

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Menu, X, User, LogOut, Home, Users, Heart, Settings, MessageCircle, Calendar, BookOpen } from 'lucide-react';
 import { useMemberStore } from '@/store/MemberStore';
 import { useTranslation } from 'react-i18next';
+import { useEditUserModalStore } from '@/store/EditUserModalStore';
 
 interface NavigationProps {
   user: any;
@@ -19,6 +20,7 @@ export default function Navigation({ user, onLogout, setMobileMenuOpen }: Naviga
   const userMenuRef = useRef<HTMLDivElement>(null);
   const member = useMemberStore((state) => state.member);
   const { t, i18n } = useTranslation();
+  const openEdit = useEditUserModalStore((s) => s.open);
 
   // Close user menu when clicking outside
   useEffect(() => {
@@ -143,6 +145,16 @@ export default function Navigation({ user, onLogout, setMobileMenuOpen }: Naviga
                         );
                       })}
                       <button
+                        onClick={() => {
+                          setIsUserMenuOpen(false);
+                          openEdit();
+                        }}
+                        className="flex items-center w-full px-4 py-2 text-sm text-sage-700 hover:bg-sage-50 transition-colors duration-200"
+                      >
+                        <User size={16} className="mr-3" />
+                        {t('editProfile')}
+                      </button>
+                      <button
                         onClick={handleLogout}
                         className="flex items-center w-full px-4 py-2 text-sm text-sage-700 hover:bg-sage-50 transition-colors duration-200"
                       >
@@ -220,6 +232,16 @@ export default function Navigation({ user, onLogout, setMobileMenuOpen }: Naviga
                 </div>
                 <span className="text-sm font-medium text-sage-700">{user?.name || (t('user') as string)}</span>
               </div>
+              <button
+                onClick={() => {
+                  openEdit();
+                  setIsMobileMenuOpenState(false);
+                }}
+                className="text-sage-600 hover:text-sage-700 hover:bg-sage-50 block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 flex items-center gap-3 w-full text-left"
+              >
+                <User size={20} />
+                {t('editProfile')}
+              </button>
               <button
                 onClick={handleLogout}
                 className="text-sage-600 hover:text-sage-700 hover:bg-sage-50 block px-3 py-2 rounded-md text-base font-medium transition-colors duration-200 flex items-center gap-3 w-full text-left"

--- a/src/store/EditUserModalStore.ts
+++ b/src/store/EditUserModalStore.ts
@@ -1,0 +1,14 @@
+'use client';
+import { create } from 'zustand';
+
+interface EditUserModalStore {
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+}
+
+export const useEditUserModalStore = create<EditUserModalStore>((set) => ({
+  isOpen: false,
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## Summary
- add modal and state store for editing user details
- integrate profile editing into header and navigation menus
- translate "edit profile" label in English, Hebrew, and Turkish locales

## Testing
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_68c2c170ed90832783d886d31ca6a1ba