### PR TITLE
feat: add pictures feed

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -88,6 +88,7 @@
   "today": "Today",
   "add": "Add",
   "noPostsYet": "No posts yet.",
+  "noPicturesYet": "No pictures yet.",
   "newPost": "New Post"
   ,
   "writePost": "Write a post"

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -88,6 +88,7 @@
   "today": "היום",
   "add": "הוסף",
   "noPostsYet": "אין פוסטים עדיין.",
+  "noPicturesYet": "אין תמונות עדיין.",
   "newPost": "פוסט חדש"
   ,
   "writePost": "כתוב פוסט"

--- a/src/app/(app)/pictures/feed/page.module.css
+++ b/src/app/(app)/pictures/feed/page.module.css
@@ -1,0 +1,12 @@
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  gap: 1rem;
+}
+
+.image {
+  width: 100%;
+  height: auto;
+  object-fit: cover;
+  border-radius: 0.5rem;
+}

--- a/src/app/(app)/pictures/feed/page.tsx
+++ b/src/app/(app)/pictures/feed/page.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import I18nText from '@/components/I18nText';
+import { apiFetch } from '@/utils/apiFetch';
+import styles from './page.module.css';
+
+interface AnniversaryOccurrence {
+  id: string;
+  date: any;
+  images?: string[];
+}
+
+function toMillis(raw: any): number {
+  if (raw?.toMillis) return raw.toMillis();
+  if (raw?.toDate) return raw.toDate().getTime();
+  if (typeof raw?._seconds === 'number') return raw._seconds * 1000;
+  if (typeof raw?.seconds === 'number') return raw.seconds * 1000;
+  return new Date(raw).getTime();
+}
+
+export default function PicturesFeedPage() {
+  const [items, setItems] = useState<AnniversaryOccurrence[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let mounted = true;
+    const run = async () => {
+      setLoading(true);
+      setError('');
+      try {
+        const data = await apiFetch<{ items: AnniversaryOccurrence[] }>('/api/pictures');
+        if (!mounted) return;
+        const sorted = [...(data.items || [])].sort((a, b) => toMillis(b.date) - toMillis(a.date));
+        setItems(sorted);
+      } catch (e) {
+        console.error(e);
+        if (mounted) setError('load');
+        throw e;
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+    run();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="p-4">
+        <I18nText k="loading" />
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <div className="p-4">
+        <I18nText k="somethingWentWrong" />
+      </div>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <div className="p-4">
+        <I18nText k="noPicturesYet" />
+      </div>
+    );
+  }
+
+  return (
+    <div className={`p-4 ${styles.grid}`}>
+      {items.map((occ) => {
+        const date = new Date(toMillis(occ.date));
+        const images = Array.isArray(occ.images) ? occ.images : [];
+        return (
+          <Card key={occ.id}>
+            <CardHeader>
+              <CardTitle>{date.toLocaleDateString()}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              {images.map((url, idx) => (
+                <img key={idx} src={url} alt="" className={styles.image} />
+              ))}
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/api/pictures/route.ts
+++ b/src/app/api/pictures/route.ts
@@ -1,0 +1,19 @@
+import { withMemberGuard } from '@/lib/withMemberGuard';
+import { AnniversaryOccurrenceRepository } from '@/repositories/AnniversaryOccurrenceRepository';
+import { GuardContext } from '@/app/api/types';
+
+export const dynamic = 'force-dynamic';
+
+const getHandler = async (_req: Request, context: GuardContext) => {
+  try {
+    const member = context.member!;
+    const repo = new AnniversaryOccurrenceRepository();
+    const items = await repo.listBySite(member.siteId);
+    return Response.json({ items });
+  } catch (error) {
+    console.error(error);
+    return Response.json({ error: 'Failed to fetch pictures' }, { status: 500 });
+  }
+};
+
+export const GET = withMemberGuard(getHandler);

--- a/src/repositories/AnniversaryOccurrenceRepository.ts
+++ b/src/repositories/AnniversaryOccurrenceRepository.ts
@@ -46,6 +46,16 @@ export class AnniversaryOccurrenceRepository {
     return qs.docs.map((d) => ({ id: d.id, ...d.data() } as AnniversaryOccurrence));
   }
 
+  async listBySite(siteId: string): Promise<AnniversaryOccurrence[]> {
+    const db = this.getDb();
+    const qs = await db
+      .collection(this.collection)
+      .where('siteId', '==', siteId)
+      .orderBy('date', 'desc')
+      .get();
+    return qs.docs.map((d) => ({ id: d.id, ...d.data() } as AnniversaryOccurrence));
+  }
+
   async update(id: string, updates: { date?: Date; imageUrl?: string | null; images?: string[] }): Promise<void> {
     const db = this.getDb();
     const data: any = {};


### PR DESCRIPTION
## Summary
- add listBySite to anniversary occurrence repository
- expose pictures feed API using member auth
- render new pictures feed page with localized strings and styles

## Testing
- `npx tsc`
- `npx next build` *(fails: Service account object must contain a string "private_key" property)*

------
https://chatgpt.com/codex/tasks/task_e_68c716272f308327ad7d5bdf345a9adf