### PR TITLE
feat: use React portal for Modal component

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,6 +18,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en">
       <body>
+        <div id="modal-root" />
         {/* Inject siteInfo for client-side access */}
         <script
           id="__SITE_INFO__"

--- a/src/components/ui/Modal.tsx
+++ b/src/components/ui/Modal.tsx
@@ -1,4 +1,7 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface ModalProps {
   isOpen: boolean;
@@ -8,9 +11,15 @@ interface ModalProps {
 }
 
 const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, isClosable = true }) => {
-  if (!isOpen) return null;
+  const [modalRoot, setModalRoot] = useState<HTMLElement | null>(null);
 
-  return (
+  useEffect(() => {
+    setModalRoot(document.getElementById('modal-root'));
+  }, []);
+
+  if (!isOpen || !modalRoot) return null;
+
+  return createPortal(
     <div
       className="fixed inset-0 flex items-center justify-center bg-black/40"
       role="dialog"
@@ -28,8 +37,10 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, children, isClosable = t
         )}
         <div>{children}</div>
       </div>
-    </div>
+    </div>,
+    modalRoot
   );
 };
 
 export default Modal;
+


### PR DESCRIPTION
## Summary
- add `#modal-root` container to the app layout
- render `Modal` using `ReactDOM.createPortal`

## Testing
- `npx tsc`
- `npx next build` *(fails: Service account object must contain a string "private_key" property)*

------
https://chatgpt.com/codex/tasks/task_e_68ab652e5f6c832780606f8905f6daf7