### PR TITLE
Add responsive mobile footer with language selector

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -256,5 +256,17 @@
   "credentialSetupGoogleHint": "We'll redirect you to Google for a quick confirmation.",
   "credentialSetupGoogleFailed": "We couldn't link Google. Please try again.",
   "credentialSetupGoogleAlreadyUsed": "This Google account is already linked to another member.",
-  "credentialSetupFirebaseUserMissing": "We couldn't find your session. Please reload and try again."
+  "credentialSetupFirebaseUserMissing": "We couldn't find your session. Please reload and try again.",
+  "languageNames": {
+    "he": "Hebrew",
+    "en": "English",
+    "tr": "Turkish"
+  },
+  "footer": {
+    "language": "Language",
+    "navigation": "Footer navigation",
+    "blog": "Blog",
+    "photo": "Photos",
+    "calendar": "Calendar"
+  }
 }

--- a/public/locales/he/common.json
+++ b/public/locales/he/common.json
@@ -256,5 +256,17 @@
   "credentialSetupGoogleHint": "נעביר אותך לגוגל להשלמת האישור.",
   "credentialSetupGoogleFailed": "לא הצלחנו לקשר את Google. נסו שוב.",
   "credentialSetupGoogleAlreadyUsed": "חשבון Google זה משויך כבר למשתמש אחר.",
-  "credentialSetupFirebaseUserMissing": "לא הצלחנו לזהות את ההתחברות. רעננו את הדף ונסו שוב."
+  "credentialSetupFirebaseUserMissing": "לא הצלחנו לזהות את ההתחברות. רעננו את הדף ונסו שוב.",
+  "languageNames": {
+    "he": "עברית",
+    "en": "אנגלית",
+    "tr": "טורקית"
+  },
+  "footer": {
+    "language": "שפה",
+    "navigation": "ניווט תחתון",
+    "blog": "בלוג",
+    "photo": "תמונות",
+    "calendar": "לוח שנה"
+  }
 }

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -246,5 +246,17 @@
   "credentialSetupGoogleHint": "Onayı tamamlamak için sizi Google'a yönlendireceğiz.",
   "credentialSetupGoogleFailed": "Google bağlantısı kurulamadı. Lütfen tekrar deneyin.",
   "credentialSetupGoogleAlreadyUsed": "Bu Google hesabı başka bir üyeyle zaten bağlantılı.",
-  "credentialSetupFirebaseUserMissing": "Oturum bulunamadı. Lütfen sayfayı yenileyip tekrar deneyin."
+  "credentialSetupFirebaseUserMissing": "Oturum bulunamadı. Lütfen sayfayı yenileyip tekrar deneyin.",
+  "languageNames": {
+    "he": "İbranice",
+    "en": "İngilizce",
+    "tr": "Türkçe"
+  },
+  "footer": {
+    "language": "Dil",
+    "navigation": "Alt gezinme",
+    "blog": "Blog",
+    "photo": "Fotoğraflar",
+    "calendar": "Takvim"
+  }
 }

--- a/src/components/ClientLayoutShell.tsx
+++ b/src/components/ClientLayoutShell.tsx
@@ -107,6 +107,7 @@ export default function ClientLayoutShell({ children }) {
           <ClientMobileShell
             t={t}
             presentationModeActive={presentationModeActive}
+            siteInfo={siteInfo}
             isLoginOpen={isLoginOpen}
             closeLogin={closeLogin}
             isPendingOpen={isPendingOpen}

--- a/src/components/ClientMobileShell.tsx
+++ b/src/components/ClientMobileShell.tsx
@@ -12,8 +12,10 @@ import PicturesFeedPage from '@/app/(app)/pictures/feed/page';
 import CalendarPage from '@/app/(app)/calendar/page';
 import BlogPage from '@/app/(app)/blog/page';
 import ShimmerImagePreview from '@/components/mobile/ShimmerImagePreview';
+import Footer from '@/components/Footer';
 import styles from './ClientLayoutShell.module.css';
 import type { TFunction } from 'i18next';
+import type { ISite } from '@/entities/Site';
 
 interface ModalControls {
   isLoginOpen: boolean;
@@ -29,11 +31,13 @@ interface ModalControls {
 interface ClientMobileShellProps extends ModalControls {
   t: TFunction;
   presentationModeActive: boolean;
+  siteInfo: ISite | null;
 }
 
 export default function ClientMobileShell({
   t,
   presentationModeActive,
+  siteInfo,
   isLoginOpen,
   closeLogin,
   isPendingOpen,
@@ -71,6 +75,7 @@ export default function ClientMobileShell({
           </SweepableElement>
         </SweepableContainer>
       </main>
+      {siteInfo && !presentationModeActive ? <Footer siteInfo={siteInfo} /> : null}
       <Modal isOpen={isLoginOpen} onClose={closeLogin}>
         <LoginPage/>
       </Modal>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { ChangeEvent, useMemo } from "react";
 import Link from 'next/link';
 import { ISite } from "@/entities/Site";
 import { useTranslation } from 'react-i18next';
@@ -12,16 +12,96 @@ interface FooterProps {
 export default function Footer({ siteInfo }: FooterProps) {
   const year = new Date().getFullYear();
   const { t, i18n } = useTranslation();
-  const localizedName = getLocalizedSiteName(siteInfo, i18n.language);
+  const rawLanguage = i18n.resolvedLanguage ?? i18n.language ?? 'he';
+  const activeLanguage = rawLanguage.split('-')[0];
+  const localizedName = getLocalizedSiteName(siteInfo, activeLanguage) || siteInfo.name;
+
+  const languageOptions = useMemo(
+    () => [
+      { code: 'he', label: t('languageNames.he', { defaultValue: 'עברית' }) as string },
+      { code: 'en', label: t('languageNames.en', { defaultValue: 'English' }) as string },
+      { code: 'tr', label: t('languageNames.tr', { defaultValue: 'Türkçe' }) as string },
+    ],
+    [t]
+  );
+
+  const navigationItems = useMemo(
+    () => [
+      { href: '/blog', label: t('footer.blog', { defaultValue: 'Blog' }) as string },
+      { href: '/pictures/feed', label: t('footer.photo', { defaultValue: 'Photos' }) as string },
+      { href: '/calendar', label: t('footer.calendar', { defaultValue: 'Calendar' }) as string },
+    ],
+    [t]
+  );
+
+  const handleLanguageChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextLanguage = event.target.value;
+    if (nextLanguage !== activeLanguage) {
+      void i18n.changeLanguage(nextLanguage);
+    }
+  };
 
   return (
-    <footer className="w-full px-4 py-6 text-center text-sm text-sage-700 border-t border-sage-200">
-      <p className="mb-2">&copy; {year} {localizedName || siteInfo.name}. {t('allRightsReserved') as string}</p>
-      <p>
-        <Link href="/terms" className="underline hover:no-underline">
-          {t('termsAndConditions')}
-        </Link>
-      </p>
+    <footer className="w-full border-t border-sage-200 bg-sage-50/80">
+      <div className="mx-auto w-full max-w-5xl px-4 py-6">
+        <div className="flex flex-col gap-6 rounded-3xl bg-white/90 p-6 shadow-sm ring-1 ring-sage-100 sm:flex-row sm:items-start sm:justify-between">
+          <div className="flex flex-col gap-3 text-left sm:max-w-md">
+            <p className="text-sm font-medium text-sage-800">
+              &copy; {year} {localizedName}. {t('allRightsReserved') as string}
+            </p>
+            <Link
+              href="/terms"
+              className="text-sm font-semibold text-sage-600 underline decoration-sage-300 underline-offset-4 transition hover:text-sage-900 hover:decoration-sage-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-500"
+            >
+              {t('termsAndConditions')}
+            </Link>
+          </div>
+
+          <div className="flex w-full flex-col gap-4 sm:max-w-xs sm:text-right">
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold uppercase tracking-wide text-sage-500">
+                {t('footer.language', { defaultValue: 'Language' }) as string}
+              </span>
+              <div className="relative">
+                <select
+                  id="footer-language-selector"
+                  aria-label={t('footer.language', { defaultValue: 'Language' }) as string}
+                  value={activeLanguage}
+                  onChange={handleLanguageChange}
+                  className="w-full appearance-none rounded-full border border-sage-300 bg-white px-4 py-2 pr-10 text-sm font-medium text-sage-700 shadow-sm transition focus:border-sage-500 focus:outline-none focus:ring-2 focus:ring-sage-200"
+                >
+                  {languageOptions.map(({ code, label }) => (
+                    <option key={code} value={code}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+                <span className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-sage-400">
+                  ▾
+                </span>
+              </div>
+            </div>
+
+            <nav
+              aria-label={t('footer.navigation', { defaultValue: 'Footer navigation' }) as string}
+              className="w-full"
+            >
+              <ul className="ml-auto flex w-full snap-x snap-mandatory items-center justify-end gap-3 overflow-x-auto pb-2 pr-1 text-sm sm:pb-0">
+                {navigationItems.map((item) => (
+                  <li key={item.href} className="snap-end">
+                    <Link
+                      href={item.href}
+                      className="inline-flex items-center rounded-full border border-sage-300 bg-white px-4 py-2 text-sm font-semibold text-sage-700 shadow-sm transition hover:border-sage-400 hover:text-sage-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sage-500"
+                    >
+                      {item.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </div>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- redesign the shared footer into a rounded, modern layout with language selector and swipeable navigation pills
- surface the footer in the mobile client shell and keep it hidden during presentation mode
- localize the new footer strings and language names across English, Hebrew, and Turkish locales

## Testing
- npx tsc

------
https://chatgpt.com/codex/tasks/task_e_68e40f86ea3483278fb17ca7da2ddfbf