### PR TITLE
Persist selected calendar month to sessionStorage

### DIFF
--- a/src/app/app/calendar/page.tsx
+++ b/src/app/app/calendar/page.tsx
@@ -38,6 +38,7 @@ export default function AnniversariesPage() {
   const [error, setError] = useState('');
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const calendarMonthKey = 'calendar-selected-month';
   const [selectedEvent, setSelectedEvent] = useState<AnniversaryEvent | null>(null);
   const [editEvent, setEditEvent] = useState<AnniversaryEvent | null>(null);
   const [imageFile, setImageFile] = useState<File | null>(null);
@@ -80,6 +81,23 @@ export default function AnniversariesPage() {
       imgRef.current.style.setProperty('--offset-y', `${offsetY}px`);
     }
   }, [offsetY]);
+
+  // Restore selected month from sessionStorage on mount
+  useEffect(() => {
+    const stored = sessionStorage.getItem(calendarMonthKey);
+    if (stored) {
+      const [y, m] = stored.split('-').map(Number);
+      if (!isNaN(y) && !isNaN(m)) {
+        setSelectedDate(new Date(y, m - 1, 1));
+      }
+    }
+  }, []);
+
+  // Persist selected month to sessionStorage whenever it changes
+  useEffect(() => {
+    const key = `${selectedDate.getFullYear()}-${String(selectedDate.getMonth() + 1).padStart(2, '0')}`;
+    sessionStorage.setItem(calendarMonthKey, key);
+  }, [selectedDate]);
 
   const fetchEvents = async (y: number, m: number) => {
     setLoading(true);


### PR DESCRIPTION
## Summary
Added functionality to persist the user's selected calendar month across page navigation and reloads using sessionStorage, improving the user experience by maintaining their browsing context.

## Key Changes
- Added `calendarMonthKey` constant to define the sessionStorage key for the selected month
- Implemented `useEffect` hook to restore the previously selected month from sessionStorage on component mount
- Implemented `useEffect` hook to persist the current selected month to sessionStorage whenever `selectedDate` changes
- Month is stored in `YYYY-MM` format for consistency and easy parsing

## Implementation Details
- The stored month format uses zero-padded month values (e.g., `2024-01` for January 2024)
- Restoration includes validation to ensure stored values are valid numbers before updating state
- The date is reconstructed using the first day of the month to avoid timezone-related issues
- Uses sessionStorage instead of localStorage to limit persistence to the current browser session

https://claude.ai/code/session_011CgxRmnGLkWhDyUDx6wKBu